### PR TITLE
Image demo viewer

### DIFF
--- a/SINGLE_IMAGE_RUN.py
+++ b/SINGLE_IMAGE_RUN.py
@@ -1,0 +1,29 @@
+import cv2
+from pathlib import Path
+
+from skelly_tracker.trackers.bright_point_tracker.brightest_point_tracker import BrightestPointTracker
+from skelly_tracker.trackers.charuco_tracker.charuco_tracker import CharucoTracker
+from skelly_tracker.trackers.mediapipe_tracker.mediapipe_holistic_tracker import MediapipeHolisticTracker
+from skelly_tracker.trackers.yolo_tracker.yolo_tracker import YOLOPoseTracker
+
+if __name__ == "__main__":
+    demo_tracker = "brightest_point_tracker"
+    image_path = Path("/Users/philipqueen/Downloads/standing_pose.JPG")
+
+    if demo_tracker == "brightest_point_tracker":
+        BrightestPointTracker().image_demo(image_path=image_path)
+
+    elif demo_tracker == "charuco_tracker":
+        CharucoTracker(squaresX=7,
+                       squaresY=5,
+                       dictionary=cv2.aruco.getPredefinedDictionary(cv2.aruco.DICT_4X4_250)).image_demo(image_path=image_path)
+
+    elif demo_tracker == "mediapipe_holistic_tracker":
+        MediapipeHolisticTracker(model_complexity=2,
+                                 min_detection_confidence=0.5,
+                                 min_tracking_confidence=0.5,
+                                 static_image_mode=False,
+                                 smooth_landmarks=True).image_demo(image_path=image_path)
+
+    elif demo_tracker == "yolo_tracker":
+        YOLOPoseTracker(model_size="high_res").image_demo(image_path=image_path)

--- a/SINGLE_IMAGE_RUN.py
+++ b/SINGLE_IMAGE_RUN.py
@@ -8,7 +8,7 @@ from skelly_tracker.trackers.yolo_tracker.yolo_tracker import YOLOPoseTracker
 
 if __name__ == "__main__":
     demo_tracker = "brightest_point_tracker"
-    image_path = Path("/Users/philipqueen/Downloads/standing_pose.JPG")
+    image_path = Path("/Path/To/Your/Image.jpg")
 
     if demo_tracker == "brightest_point_tracker":
         BrightestPointTracker().image_demo(image_path=image_path)

--- a/skelly_tracker/trackers/base_tracker/base_tracker.py
+++ b/skelly_tracker/trackers/base_tracker/base_tracker.py
@@ -1,6 +1,8 @@
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Any, Dict, Callable, Optional, List
 import numpy as np
+from skelly_tracker.trackers.image_demo_viewer.image_demo_viewer import ImageDemoViewer
 from skelly_tracker.trackers.webcam_demo_viewer.webcam_demo_viewer import WebcamDemoViewer
 from typing import List
 from dataclasses import dataclass, field
@@ -62,3 +64,13 @@ class BaseTracker(ABC):
         """
         camera_viewer = WebcamDemoViewer(self, self.__class__.__name__)
         camera_viewer.run()
+
+    def image_demo(self, image_path: Path) -> None:
+        """
+        Run tracker on single image
+        
+        :return: None
+        """
+
+        image_viewer = ImageDemoViewer(self, self.__class__.__name__)
+        image_viewer.run(image_path=image_path)

--- a/skelly_tracker/trackers/image_demo_viewer/image_demo_viewer.py
+++ b/skelly_tracker/trackers/image_demo_viewer/image_demo_viewer.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+import cv2
+
+# Constants for key actions
+KEY_QUIT = ord("q")
+
+class ImageDemoViewer:
+    def __init__(self, tracker, window_title: str = None):
+        """
+        Initialize with a tracker and optional window title and default exposure.
+        """
+        self.tracker = tracker
+        if window_title is None:
+            window_title = f"{tracker.__class__.__name__}"
+        self.window_title = window_title
+
+    def run(self, image_path: Path):
+        """
+        Display input image
+        """
+        image = cv2.imread(str(image_path))
+
+        tracked_results = self.tracker.process_image(image)
+        print(tracked_results)
+        annotated_image = self.tracker.annotated_image
+
+        cv2.imshow(self.window_title, annotated_image)
+
+        cv2.waitKey(0)
+
+        cv2.destroyAllWindows()


### PR DESCRIPTION
This is a simpler demo that allows a single image path as an input and runs the selected tracker on the image. It also prints the result. 

It's not very interesting, but I made it quickly to be able to compare the results output of the different trackers. The goal is to use it while adding trackers to help make sure the `tracked_objects` output is consistent between trackers.