### PR TITLE
Philip/multiperson tracking with yolo

### DIFF
--- a/SINGLE_IMAGE_RUN.py
+++ b/SINGLE_IMAGE_RUN.py
@@ -1,0 +1,29 @@
+import cv2
+from pathlib import Path
+
+from skelly_tracker.trackers.bright_point_tracker.brightest_point_tracker import BrightestPointTracker
+from skelly_tracker.trackers.charuco_tracker.charuco_tracker import CharucoTracker
+from skelly_tracker.trackers.mediapipe_tracker.mediapipe_holistic_tracker import MediapipeHolisticTracker
+from skelly_tracker.trackers.yolo_tracker.yolo_tracker import YOLOPoseTracker
+
+if __name__ == "__main__":
+    demo_tracker = "brightest_point_tracker"
+    image_path = Path("/Users/philipqueen/Downloads/standing_pose.JPG")
+
+    if demo_tracker == "brightest_point_tracker":
+        BrightestPointTracker().image_demo(image_path=image_path)
+
+    elif demo_tracker == "charuco_tracker":
+        CharucoTracker(squaresX=7,
+                       squaresY=5,
+                       dictionary=cv2.aruco.getPredefinedDictionary(cv2.aruco.DICT_4X4_250)).image_demo(image_path=image_path)
+
+    elif demo_tracker == "mediapipe_holistic_tracker":
+        MediapipeHolisticTracker(model_complexity=2,
+                                 min_detection_confidence=0.5,
+                                 min_tracking_confidence=0.5,
+                                 static_image_mode=False,
+                                 smooth_landmarks=True).image_demo(image_path=image_path)
+
+    elif demo_tracker == "yolo_tracker":
+        YOLOPoseTracker(model_size="high_res").image_demo(image_path=image_path)

--- a/SINGLE_IMAGE_RUN.py
+++ b/SINGLE_IMAGE_RUN.py
@@ -8,7 +8,7 @@ from skelly_tracker.trackers.yolo_tracker.yolo_tracker import YOLOPoseTracker
 
 if __name__ == "__main__":
     demo_tracker = "brightest_point_tracker"
-    image_path = Path("/Users/philipqueen/Downloads/standing_pose.JPG")
+    image_path = Path("/Path/To/Your/Image.jpg")
 
     if demo_tracker == "brightest_point_tracker":
         BrightestPointTracker().image_demo(image_path=image_path)

--- a/skelly_tracker/trackers/base_tracker/base_tracker.py
+++ b/skelly_tracker/trackers/base_tracker/base_tracker.py
@@ -1,6 +1,8 @@
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Any, Dict, Callable, Optional, List
 import numpy as np
+from skelly_tracker.trackers.image_demo_viewer.image_demo_viewer import ImageDemoViewer
 from skelly_tracker.trackers.webcam_demo_viewer.webcam_demo_viewer import WebcamDemoViewer
 from typing import List
 from dataclasses import dataclass, field
@@ -62,3 +64,13 @@ class BaseTracker(ABC):
         """
         camera_viewer = WebcamDemoViewer(self, self.__class__.__name__)
         camera_viewer.run()
+
+    def image_demo(self, image_path: Path) -> None:
+        """
+        Run tracker on single image
+        
+        :return: None
+        """
+
+        image_viewer = ImageDemoViewer(self, self.__class__.__name__)
+        image_viewer.run(image_path=image_path)

--- a/skelly_tracker/trackers/image_demo_viewer/image_demo_viewer.py
+++ b/skelly_tracker/trackers/image_demo_viewer/image_demo_viewer.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+import cv2
+
+# Constants for key actions
+KEY_QUIT = ord("q")
+
+class ImageDemoViewer:
+    def __init__(self, tracker, window_title: str = None):
+        """
+        Initialize with a tracker and optional window title and default exposure.
+        """
+        self.tracker = tracker
+        if window_title is None:
+            window_title = f"{tracker.__class__.__name__}"
+        self.window_title = window_title
+
+    def run(self, image_path: Path):
+        """
+        Display input image
+        """
+        image = cv2.imread(str(image_path))
+
+        tracked_results = self.tracker.process_image(image)
+        print(tracked_results)
+        annotated_image = self.tracker.annotated_image
+
+        cv2.imshow(self.window_title, annotated_image)
+
+        cv2.waitKey(0)
+
+        cv2.destroyAllWindows()

--- a/skelly_tracker/trackers/yolo_tracker/yolo_tracker.py
+++ b/skelly_tracker/trackers/yolo_tracker/yolo_tracker.py
@@ -8,7 +8,7 @@ from skelly_tracker.trackers.yolo_tracker.yolo_model_dictionary import yolo_mode
 
 class YOLOPoseTracker(BaseTracker):
     def __init__(self, model_size: str="nano"):
-        super().__init__(tracked_object_names=["human_pose"])
+        super().__init__(tracked_object_names=[])
 
         pytorch_model = yolo_model_dictionary[model_size]
         self.model = YOLO(pytorch_model)
@@ -16,15 +16,27 @@ class YOLOPoseTracker(BaseTracker):
     def process_image(self, image, **kwargs):
         results = self.model(image)
 
-        self.tracked_objects["human_pose"].extra["landmarks"] = np.array(results[0].keypoints)
+        self.unpack_results(results)
 
         self.annotated_image = self.annotate_image(image, results=results, **kwargs)
 
         return self.tracked_objects
 
     def annotate_image(self, image: np.ndarray, results, **kwargs) -> np.ndarray:
-        return results[0].plot()
+        return results[-1].plot()
+    
+    def unpack_results(self, results):
+        tracked_person_number = 0
+        for tracked_person in np.array(results[-1].keypoints):
+            tracked_person_name = f"tracked_person_{tracked_person_number}"
+            
+            self.tracked_objects[tracked_person_name] = TrackedObject(object_id=tracked_person_name)
+            self.tracked_objects[tracked_person_name].extra["landmarks"] = []
+            self.tracked_objects[tracked_person_name].extra["landmarks"].append(tracked_person)
+
+            tracked_person_number += 1
         
 
 if __name__ == "__main__":
     YOLOPoseTracker().demo()
+


### PR DESCRIPTION
This PR adds better handling of the multi-person YOLO pose estimation results by separating each person tracked into a separate tracked object. Instead of initializing with all of the tracked objects it plans to have, it adds an `unpack results` function that creates a tracked object for each person found in the image, allowing it to track an arbitrary number of people while maintaining a similar structure to the mediapipe holistic tracker.

The big hurdle in getting to multi-person 3d tracking with this will be telling which person is which between the different 2d image views. Here are some papers that discuss solutions to this problem:
Matching approaches (most relevant to us)
[3D pictorial structures (3DPS) model that infers
skeletons of multiple humans from a reduced state space
of 3D body part hypotheses](https://openaccess.thecvf.com/content_cvpr_2014/papers/Belagiannis_3D_Pictorial_Structures_2014_CVPR_paper.pdf)
[Multi-way matching algorithm to cluster
the detected 2D poses in all views](https://openaccess.thecvf.com/content_CVPR_2019/papers/Dong_Fast_and_Robust_Multi-Person_3D_Pose_Estimation_From_Multiple_Views_CVPR_2019_paper.pdf)
Natively 3D approaches (less relevant unless any easy to implement version is released)
[Directly regress the actual 3D joint locations](https://proceedings.neurips.cc/paper_files/paper/2021/file/6da9003b743b65f4c0ccd295cc484e57-Paper.pdf)
[Multi-view Matching Graph Module (MMG)](https://arxiv.org/abs/2109.05885)
[CTP (Center Point to Pose) network based on multi-view which directly operates in the 3D space](https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0274450)