### PR TITLE
Philip/across frame tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,5 @@ cython_debug/
 
 .DS_Store
 skelly_tracker/utilities/quine_directory_printer/output/*
+*.pt
+bus.jpg

--- a/RUN_ME.py
+++ b/RUN_ME.py
@@ -9,9 +9,7 @@ from skelly_tracker.trackers.yolo_object_tracker.yolo_object_tracker import YOLO
 
 if __name__ == "__main__":
 
-#    demo_tracker = "SAM_tracker"
-    demo_tracker = "yolo_object_tracker"
-
+    demo_tracker = "brightest_point_tracker"
 
     if demo_tracker == "brightest_point_tracker":
         BrightestPointTracker().demo()
@@ -30,7 +28,9 @@ if __name__ == "__main__":
 
     elif demo_tracker == "yolo_tracker":
         YOLOPoseTracker(model_size="high_res").demo()
+
     elif demo_tracker == "SAM_tracker":
         SAMTracker().demo()
+
     elif demo_tracker == "yolo_object_tracker":
         YOLOObjectTracker(model_size="medium").demo()

--- a/skelly_tracker/trackers/base_tracker/base_tracker.py
+++ b/skelly_tracker/trackers/base_tracker/base_tracker.py
@@ -34,6 +34,8 @@ class BaseTracker(ABC):
         for name in tracked_object_names:
             self.tracked_objects[name] = TrackedObject(object_id=name)
 
+        self.tracked_objects_across_frames = []
+
     @abstractmethod
     def process_image(self, image: np.ndarray, **kwargs) -> Dict[str, TrackedObject]:
         """

--- a/skelly_tracker/trackers/bright_point_tracker/brightest_point_tracker.py
+++ b/skelly_tracker/trackers/bright_point_tracker/brightest_point_tracker.py
@@ -52,7 +52,9 @@ class BrightestPointTracker(BaseTracker):
             self.tracked_objects["brightest_point"].pixel_y = largest_patch_centroid[1]
             self.tracked_objects["brightest_point"].extra["thresholded_image"] = thresholded_image
 
-        self.tracked_objects_across_frames.append(copy.deepcopy(self.tracked_objects["brightest_point"]))
+        tracked_object_copy = copy.deepcopy(self.tracked_objects["brightest_point"])
+        tracked_object_copy.extra["thresholded_image"] = None
+        self.tracked_objects_across_frames.append(tracked_object_copy)
 
         self.raw_image = image.copy()
 


### PR DESCRIPTION
Stores the tracked object data for the brightest point and displays the last ten frames of data on the annotated image.

Right now it makes one very minor change to the base tracker (creating an empty list in the init function).

<img width="949" alt="Screen Shot 2023-06-01 at 8 16 05 PM" src="https://github.com/freemocap/skellytracker/assets/24758117/d6668508-18e6-4f33-8be8-158f08859472">
