### PR TITLE
Freemocap updates

### DIFF
--- a/skelly_tracker/process_folder_of_videos.py
+++ b/skelly_tracker/process_folder_of_videos.py
@@ -36,7 +36,7 @@ def process_folder_of_videos(
     tracker_name: str,
     tracking_params: BaseModel,
     synchronized_video_path: Path,
-    output_path: Optional[Path] = None,
+    output_folder_path: Optional[Path] = None,
     annotated_video_path: Optional[Path] = None,
     num_processes: int = None,
 ) -> None:
@@ -47,7 +47,7 @@ def process_folder_of_videos(
     :param tracker_name: Tracker to use.
     :param tracking_params: Tracking parameters to use.
     :param synchronized_video_path: Path to folder of synchronized videos.
-    :param output_path: Path to save tracked data to.
+    :param output_folder_path: Path to save tracked data to.
     :param annotated_video_path: Path to save annotated videos to.
     :param num_processes: Number of processes to use, 1 to disable multiprocessing.
     :return: Array of tracking data
@@ -63,6 +63,8 @@ def process_folder_of_videos(
         output_path = (
             synchronized_video_path.parent / "output_data" / "raw_data" / file_name
         )
+    else:
+        output_path = Path(output_path) / file_name
     if not output_path.exists():
         output_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/skelly_tracker/trackers/base_tracker/base_tracking_params.py
+++ b/skelly_tracker/trackers/base_tracker/base_tracking_params.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel
+
+
+class BaseTrackingParams(BaseModel):
+    num_processes: int = 1
+    run_image_tracking: bool = True

--- a/skelly_tracker/trackers/mediapipe_tracker/mediapipe_model_info.py
+++ b/skelly_tracker/trackers/mediapipe_tracker/mediapipe_model_info.py
@@ -1,6 +1,7 @@
 from mediapipe.python.solutions import holistic as mp_holistic
 from mediapipe.python.solutions.face_mesh import FACEMESH_NUM_LANDMARKS_WITH_IRISES
-from pydantic import BaseModel
+
+from skelly_tracker.trackers.base_tracker.base_tracking_params import BaseTrackingParams
 
 mediapipe_body_landmark_names = [
     landmark.name.lower() for landmark in mp_holistic.PoseLandmark
@@ -28,7 +29,7 @@ class MediapipeModelInfo:
     ]
 
 
-class MediapipeTrackingParams(BaseModel):
+class MediapipeTrackingParams(BaseTrackingParams):
     mediapipe_model_complexity: int = 1
     min_detection_confidence: float = 0.5
     min_tracking_confidence: float = 0.5

--- a/skelly_tracker/trackers/yolo_object_tracker/yolo_object_model_info.py
+++ b/skelly_tracker/trackers/yolo_object_tracker/yolo_object_model_info.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from skelly_tracker.trackers.base_tracker.base_tracking_params import BaseTrackingParams
 
 
 yolo_object_model_dictionary = {
@@ -10,7 +10,7 @@ yolo_object_model_dictionary = {
 }
 
 
-class YOLOObjectTrackingParams(BaseModel):
+class YOLOObjectTrackingParams(BaseTrackingParams):
     model_size: str = "medium"
     person_only: bool = True
     confidence_threshold: float = 0.5

--- a/skelly_tracker/trackers/yolo_tracker/yolo_model_info.py
+++ b/skelly_tracker/trackers/yolo_tracker/yolo_model_info.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from skelly_tracker.trackers.base_tracker.base_tracking_params import BaseTrackingParams
 
 
 class YOLOModelInfo:
@@ -79,5 +79,6 @@ class YOLOModelInfo:
         0.061,
     ]
 
-class YOLOTrackingParams(BaseModel):
+
+class YOLOTrackingParams(BaseTrackingParams):
     model_size: str = "medium"


### PR DESCRIPTION
Updates to get skellytracker compatible with Freemocap:
- fixes the output data path in `process_folder_of_videos`
- implements a base class for tracking params that includes the multiprocessing and "run_2d_tracking" properties that freemocap will always need

