### PR TITLE
Set use_yolo_crop_method default to false

### DIFF
--- a/skellytracker/trackers/mediapipe_tracker/mediapipe_model_info.py
+++ b/skellytracker/trackers/mediapipe_tracker/mediapipe_model_info.py
@@ -30,7 +30,7 @@ class MediapipeModelInfo:
 
 
 class MediapipeTrackingParams(BaseTrackingParams):
-    use_yolo_crop_method: bool = True
+    use_yolo_crop_method: bool = False
     mediapipe_model_complexity: int = 2
     min_detection_confidence: float = 0.5
     min_tracking_confidence: float = 0.5


### PR DESCRIPTION
Simple change to set the default to be standard mediapipe processing. This is due to a very occasional problem where the YOLO cropping appears to hang.