### PR TITLE
Patch process folder of videos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,4 @@ cython_debug/
 *.jpeg
 
 skellytracker/utilities/quine_directory_printer/output/*
+recorded_objects.npy

--- a/RUN_ME.py
+++ b/RUN_ME.py
@@ -9,7 +9,7 @@ from skellytracker.trackers.yolo_object_tracker.yolo_object_tracker import YOLOO
 
 if __name__ == "__main__":
 
-    demo_tracker = "yolo_object_tracker"
+    demo_tracker = "yolo_tracker"
 
 
     if demo_tracker == "brightest_point_tracker":

--- a/RUN_ME.py
+++ b/RUN_ME.py
@@ -16,8 +16,13 @@ if __name__ == "__main__":
         BrightestPointTracker().demo()
 
     elif demo_tracker == "charuco_tracker":
-        CharucoTracker(squaresX=7,
-                       squaresY=5,
+        charuco_squares_x = 7
+        charuco_squares_y = 5
+        number_of_charuco_markers = charuco_squares_x - 1 * charuco_squares_y - 1
+        charuco_ids = [str(index) for index in range(number_of_charuco_markers)]
+        CharucoTracker(tracked_object_names=charuco_ids, 
+                       squares_x=charuco_squares_x,
+                       squares_y=charuco_squares_y,
                        dictionary=cv2.aruco.getPredefinedDictionary(cv2.aruco.DICT_4X4_250)).demo()
 
     elif demo_tracker == "mediapipe_holistic_tracker":

--- a/RUN_ME.py
+++ b/RUN_ME.py
@@ -28,8 +28,10 @@ if __name__ == "__main__":
                                  smooth_landmarks=True).demo()
 
     elif demo_tracker == "yolo_tracker":
-        YOLOPoseTracker(model_size="high_res").demo()
+        YOLOPoseTracker(model_size="nano").demo()
     elif demo_tracker == "SAM_tracker":
         SAMTracker().demo()
     elif demo_tracker == "yolo_object_tracker":
         YOLOObjectTracker(model_size="medium").demo()
+    else:
+        raise ValueError("Invalid tracker type")

--- a/SINGLE_IMAGE_RUN.py
+++ b/SINGLE_IMAGE_RUN.py
@@ -1,29 +1,46 @@
 import cv2
 from pathlib import Path
 
-from skellytracker.trackers.bright_point_tracker.brightest_point_tracker import BrightestPointTracker
+from skellytracker.trackers.bright_point_tracker.brightest_point_tracker import (
+    BrightestPointTracker,
+)
 from skellytracker.trackers.charuco_tracker.charuco_tracker import CharucoTracker
-from skellytracker.trackers.mediapipe_tracker.mediapipe_holistic_tracker import MediapipeHolisticTracker
+from skellytracker.trackers.mediapipe_tracker.mediapipe_holistic_tracker import (
+    MediapipeHolisticTracker,
+)
+from skellytracker.trackers.yolo_object_tracker.yolo_object_tracker import (
+    YOLOObjectTracker,
+)
 from skellytracker.trackers.yolo_tracker.yolo_tracker import YOLOPoseTracker
 
 if __name__ == "__main__":
-    demo_tracker = "brightest_point_tracker"
+    demo_tracker = "yolo_object_tracker"
     image_path = Path("/Path/To/Your/Image.jpg")
 
     if demo_tracker == "brightest_point_tracker":
         BrightestPointTracker().image_demo(image_path=image_path)
 
     elif demo_tracker == "charuco_tracker":
-        CharucoTracker(squaresX=7,
-                       squaresY=5,
-                       dictionary=cv2.aruco.getPredefinedDictionary(cv2.aruco.DICT_4X4_250)).image_demo(image_path=image_path)
+        CharucoTracker(
+            squaresX=7,
+            squaresY=5,
+            dictionary=cv2.aruco.getPredefinedDictionary(cv2.aruco.DICT_4X4_250),
+        ).image_demo(image_path=image_path)
 
     elif demo_tracker == "mediapipe_holistic_tracker":
-        MediapipeHolisticTracker(model_complexity=2,
-                                 min_detection_confidence=0.5,
-                                 min_tracking_confidence=0.5,
-                                 static_image_mode=False,
-                                 smooth_landmarks=True).image_demo(image_path=image_path)
+        MediapipeHolisticTracker(
+            model_complexity=2,
+            min_detection_confidence=0.5,
+            min_tracking_confidence=0.5,
+            static_image_mode=False,
+            smooth_landmarks=True,
+        ).image_demo(image_path=image_path)
 
     elif demo_tracker == "yolo_tracker":
         YOLOPoseTracker(model_size="high_res").image_demo(image_path=image_path)
+
+    elif demo_tracker == "yolo_object_tracker":
+        YOLOObjectTracker(model_size="nano").image_demo(image_path=image_path)
+
+    else:
+        raise ValueError("Invalid tracker type")

--- a/SINGLE_IMAGE_RUN.py
+++ b/SINGLE_IMAGE_RUN.py
@@ -21,9 +21,14 @@ if __name__ == "__main__":
         BrightestPointTracker().image_demo(image_path=image_path)
 
     elif demo_tracker == "charuco_tracker":
+        charuco_squares_x = 7
+        charuco_squares_y = 5
+        number_of_charuco_markers = charuco_squares_x - 1 * charuco_squares_y - 1
+        charuco_ids = [str(index) for index in range(number_of_charuco_markers)]
         CharucoTracker(
-            squaresX=7,
-            squaresY=5,
+            tracked_object_names=charuco_ids,
+            squares_x=charuco_squares_x,
+            squares_y=charuco_squares_y,
             dictionary=cv2.aruco.getPredefinedDictionary(cv2.aruco.DICT_4X4_250),
         ).image_demo(image_path=image_path)
 

--- a/SINGLE_IMAGE_RUN.py
+++ b/SINGLE_IMAGE_RUN.py
@@ -14,8 +14,8 @@ from skellytracker.trackers.yolo_object_tracker.yolo_object_tracker import (
 from skellytracker.trackers.yolo_tracker.yolo_tracker import YOLOPoseTracker
 
 if __name__ == "__main__":
-    demo_tracker = "yolo_object_tracker"
-    image_path = Path("/Path/To/Your/Image.jpg")
+    demo_tracker = "yolo_tracker"
+    image_path = Path("bus.jpg")
 
     if demo_tracker == "brightest_point_tracker":
         BrightestPointTracker().image_demo(image_path=image_path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,8 +58,10 @@ dependencies = [
     "opencv-contrib-python==4.8.*",
     "pyside6~=6.6.0",
     "pydantic==1.*",
-    "mediapipe~=0.10.*",
+    "mediapipe==0.10.*",
     "ultralytics~=8.1.5",
+    torch==2.1.2,
+    torchvision==0.16.2
 ]
 requires-python = ">=3.9,<3.12"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,8 +58,8 @@ dependencies = [
     "opencv-contrib-python==4.8.*",
     "pyside6~=6.6.0",
     "pydantic==1.*",
-    "mediapipe~=0.10.0",
-    "ultralytics~=8.0.202",
+    "mediapipe~=0.10.*",
+    "ultralytics~=8.1.5",
 ]
 requires-python = ">=3.9,<3.12"
 

--- a/skellytracker/process_folder_of_videos.py
+++ b/skellytracker/process_folder_of_videos.py
@@ -1,13 +1,13 @@
 import logging
 from multiprocessing import Pool, cpu_count
 from pathlib import Path
-import sys
-from typing import Any, Optional, Type
+from typing import Optional, Union
 import numpy as np
 from pydantic import BaseModel
 
 
 from skellytracker.trackers.base_tracker.base_tracker import BaseTracker
+from skellytracker.trackers.base_tracker.base_tracking_params import BaseTrackingParams
 from skellytracker.trackers.bright_point_tracker.brightest_point_tracker import (
     BrightestPointTracker,
 )
@@ -18,6 +18,7 @@ from skellytracker.trackers.yolo_mediapipe_combo_tracker.yolo_mediapipe_combo_tr
     YOLOMediapipeComboTracker,
 )
 from skellytracker.trackers.yolo_tracker.yolo_tracker import YOLOPoseTracker
+from skellytracker.trackers.yolo_tracker.yolo_model_info import YOLOTrackingParams
 from skellytracker.trackers.mediapipe_tracker.mediapipe_model_info import (
     MediapipeTrackingParams,
 )
@@ -38,7 +39,7 @@ def process_folder_of_videos(
     synchronized_video_path: Path,
     output_folder_path: Optional[Path] = None,
     annotated_video_path: Optional[Path] = None,
-    num_processes: int = None,
+    num_processes: Optional[int] = None,
 ) -> np.ndarray:
     """
     Process a folder of synchronized videos with the given tracker.
@@ -126,12 +127,17 @@ def process_single_video(
     return output_array
 
 
-def get_tracker(tracker_name: str, tracking_params: BaseModel) -> BaseTracker:
+def get_tracker(
+    tracker_name: str,
+    tracking_params: Union[
+        BaseTrackingParams, MediapipeTrackingParams, YOLOTrackingParams
+    ],
+) -> BaseTracker:
     """
     Returns a tracker object based on the given tracker_type and tracking_params.
 
     :param tracker_type (str): The type of tracker to be created.
-    :param tracking_params (BaseModel): The tracking parameters to be used for creating the tracker.
+    :param tracking_params (Union[BaseTrackingParams, MediapipeTrackingParams, YOLOTrackingParams],): The tracking parameters to be used for creating the tracker.
     :return BaseTracker: The tracker object based on the given tracker_type and tracking_params.
     :raise ValueError: If an invalid tracker_type is provided.
     """
@@ -153,7 +159,7 @@ def get_tracker(tracker_name: str, tracking_params: BaseModel) -> BaseTracker:
 
     elif tracker_name == "YOLOPoseTracker":
         tracker = YOLOPoseTracker(
-            model_size="medium",
+            model_size=tracking_params.model_size,
         )
 
     elif tracker_name == "BrightestPointTracker":

--- a/skellytracker/process_folder_of_videos.py
+++ b/skellytracker/process_folder_of_videos.py
@@ -21,6 +21,7 @@ from skellytracker.trackers.yolo_tracker.yolo_tracker import YOLOPoseTracker
 from skellytracker.trackers.mediapipe_tracker.mediapipe_model_info import (
     MediapipeTrackingParams,
 )
+from skellytracker.utilities.get_video_paths import get_video_paths
 
 logger = logging.getLogger(__name__)
 
@@ -52,9 +53,15 @@ def process_folder_of_videos(
     :param num_processes: Number of processes to use, 1 to disable multiprocessing.
     :return: Array of tracking data
     """
+    video_paths = get_video_paths(synchronized_video_path)
+
     if num_processes is None:
         num_processes = min(
-            (cpu_count() - 1), len(list(synchronized_video_path.glob("*.mp4")))
+            (cpu_count() - 1), len(video_paths)
+        )
+    else:
+        num_processes = min(
+            num_processes, len(video_paths)
         )
 
     file_name = file_name_dictionary[tracker_name]
@@ -75,7 +82,7 @@ def process_folder_of_videos(
 
     tasks = [
         (tracker_name, tracking_params, video_path, annotated_video_path)
-        for video_path in synchronized_video_path.glob("*.mp4")
+        for video_path in video_paths
     ]
 
     if num_processes > 1:

--- a/skellytracker/process_folder_of_videos.py
+++ b/skellytracker/process_folder_of_videos.py
@@ -61,7 +61,7 @@ def process_folder_of_videos(
         )
     else:
         num_processes = min(
-            num_processes, len(video_paths)
+            num_processes, len(video_paths), cpu_count() - 1
         )
 
     file_name = file_name_dictionary[tracker_name]

--- a/skellytracker/process_folder_of_videos.py
+++ b/skellytracker/process_folder_of_videos.py
@@ -22,6 +22,7 @@ from skellytracker.trackers.yolo_tracker.yolo_model_info import YOLOTrackingPara
 from skellytracker.trackers.mediapipe_tracker.mediapipe_model_info import (
     MediapipeTrackingParams,
 )
+from skellytracker.utilities.get_video_paths import get_video_paths
 
 logger = logging.getLogger(__name__)
 
@@ -53,9 +54,15 @@ def process_folder_of_videos(
     :param num_processes: Number of processes to use, 1 to disable multiprocessing.
     :return: Array of tracking data
     """
+    video_paths = get_video_paths(synchronized_video_path)
+
     if num_processes is None:
         num_processes = min(
-            (cpu_count() - 1), len(list(synchronized_video_path.glob("*.mp4")))
+            (cpu_count() - 1), len(video_paths)
+        )
+    else:
+        num_processes = min(
+            num_processes, len(video_paths)
         )
 
     file_name = file_name_dictionary[tracker_name]
@@ -76,7 +83,7 @@ def process_folder_of_videos(
 
     tasks = [
         (tracker_name, tracking_params, video_path, annotated_video_path)
-        for video_path in synchronized_video_path.glob("*.mp4")
+        for video_path in video_paths
     ]
 
     if num_processes > 1:

--- a/skellytracker/process_folder_of_videos.py
+++ b/skellytracker/process_folder_of_videos.py
@@ -62,7 +62,7 @@ def process_folder_of_videos(
         )
     else:
         num_processes = min(
-            num_processes, len(video_paths)
+            num_processes, len(video_paths), cpu_count() - 1
         )
 
     file_name = file_name_dictionary[tracker_name]

--- a/skellytracker/trackers/charuco_tracker/charuco_tracker.py
+++ b/skellytracker/trackers/charuco_tracker/charuco_tracker.py
@@ -12,19 +12,20 @@ class CharucoTracker(BaseTracker):
                  tracked_object_names: List[str],
                  squares_x: int,
                  squares_y: int,
-                 dictionary: cv2.aruco_Dictionary,
+                 dictionary: cv2.aruco.Dictionary,
                  squareLength: float = 1,
                  markerLength: float = .8,
                  ):
         super().__init__(tracked_object_names=tracked_object_names)
-        self.board = cv2.aruco.CharucoBoard_create(squares_x, squares_y, squareLength, markerLength, dictionary)
+        self.board = cv2.aruco.CharucoBoard([squares_x, squares_y], squareLength, markerLength, dictionary)
+        self.dictionary = dictionary
 
     def process_image(self, image: np.ndarray, **kwargs) -> Dict[str, TrackedObject]:
         # Convert the image to grayscale
         gray_image = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
 
         # Detect Aruco markers
-        corners, ids, _ = cv2.aruco.detectMarkers(gray_image, self.board.dictionary)
+        corners, ids, _ = cv2.aruco.detectMarkers(gray_image, self.dictionary)
 
         # If any markers were found
         if len(corners) > 0:
@@ -66,13 +67,13 @@ class CharucoTracker(BaseTracker):
 
 
 if __name__ == "__main__":
-    charuco_squares_x_in = 7
-    charuco_squares_y_in = 5
-    number_of_charuco_markers = charuco_squares_x_in - 1 * charuco_squares_y_in - 1
+    charuco_squares_x = 7
+    charuco_squares_y = 5
+    number_of_charuco_markers = charuco_squares_x - 1 * charuco_squares_y - 1
     charuco_ids = [str(index) for index in range(number_of_charuco_markers)]
 
     CharucoTracker(tracked_object_names=charuco_ids,
-                   squares_x=charuco_squares_x_in,
-                   squares_y=charuco_squares_y_in,
-                   dictionary=cv2.aruco.Dictionary_get(cv2.aruco.DICT_4X4_250)
+                   squares_x=charuco_squares_x,
+                   squares_y=charuco_squares_y,
+                   dictionary=cv2.aruco.getPredefinedDictionary(cv2.aruco.DICT_4X4_250)
                    ).demo()

--- a/skellytracker/trackers/yolo_object_tracker/yolo_object_model_info.py
+++ b/skellytracker/trackers/yolo_object_tracker/yolo_object_model_info.py
@@ -14,3 +14,4 @@ class YOLOObjectTrackingParams(BaseTrackingParams):
     model_size: str = "medium"
     person_only: bool = True
     confidence_threshold: float = 0.5
+    use_gpu: bool = True

--- a/skellytracker/trackers/yolo_object_tracker/yolo_object_tracker.py
+++ b/skellytracker/trackers/yolo_object_tracker/yolo_object_tracker.py
@@ -21,6 +21,7 @@ class YOLOObjectTracker(BaseTracker):
         model_size: str = "nano",
         person_only: bool = True,
         confidence_threshold: float = 0.5,
+        use_gpu: bool = True,
     ):
         super().__init__(tracked_object_names=["object"], recorder=YOLOObjectRecorder())
 
@@ -32,10 +33,10 @@ class YOLOObjectTracker(BaseTracker):
         else:
             self.classes = None
 
-        if cuda.is_available():
+        if cuda.is_available() and use_gpu:
             self.device = "0"
             cuda.set_device(int(self.device))
-        elif backends.mps.is_available():
+        elif backends.mps.is_available() and use_gpu:
             self.device = "mps"
         else:
             self.device = "cpu"
@@ -45,7 +46,7 @@ class YOLOObjectTracker(BaseTracker):
             image,
             classes=self.classes,
             max_det=1,
-            verbose=True,
+            verbose=False,
             conf=self.confidence_threshold,
             device=self.device,
         )

--- a/skellytracker/trackers/yolo_object_tracker/yolo_object_tracker.py
+++ b/skellytracker/trackers/yolo_object_tracker/yolo_object_tracker.py
@@ -1,3 +1,4 @@
+from torch import cuda, backends
 import numpy as np
 from typing import Dict
 from ultralytics import YOLO
@@ -29,8 +30,24 @@ class YOLOObjectTracker(BaseTracker):
         else:
             self.classes = None
 
+        if cuda.is_available():
+            self.device = "0"
+            cuda.set_device(int(self.device))
+        elif backends.mps.is_available():
+            self.device = "mps"
+        else:
+            self.device = "cpu"
+        # self.device = "cpu"
+
     def process_image(self, image, **kwargs) -> Dict[str, TrackedObject]:
-        results = self.model(image, classes=self.classes, max_det=1, verbose=False, conf=self.confidence_threshold)
+        results = self.model(
+            image,
+            classes=self.classes,
+            max_det=1,
+            verbose=False,
+            conf=self.confidence_threshold,
+            device=self.device,
+        )
 
         box_xyxy = np.asarray(results[0].boxes.xyxy).flatten()
 

--- a/skellytracker/trackers/yolo_tracker/yolo_model_info.py
+++ b/skellytracker/trackers/yolo_tracker/yolo_model_info.py
@@ -82,3 +82,4 @@ class YOLOModelInfo:
 
 class YOLOTrackingParams(BaseTrackingParams):
     model_size: str = "medium"
+    use_gpu: bool = True

--- a/skellytracker/trackers/yolo_tracker/yolo_tracker.py
+++ b/skellytracker/trackers/yolo_tracker/yolo_tracker.py
@@ -1,4 +1,4 @@
-from torch import cuda
+from torch import cuda, backends, Tensor
 import numpy as np
 from typing import Dict
 from ultralytics import YOLO
@@ -10,22 +10,22 @@ from skellytracker.trackers.yolo_tracker.yolo_recorder import YOLORecorder
 
 
 class YOLOPoseTracker(BaseTracker):
-    def __init__(self, model_size: str = "nano"):
+    def __init__(self, model_size: str = "nano", use_gpu: bool = True):
         super().__init__(tracked_object_names=[], recorder=YOLORecorder())
 
         pytorch_model = YOLOModelInfo.model_dictionary[model_size]
         self.model = YOLO(pytorch_model)
-        # metal (mps) is currently not supported for YOLO pose
-        if cuda.is_available():
+        if cuda.is_available() and use_gpu:
             self.device = "0"
             cuda.set_device(int(self.device))
+        elif backends.mps.is_available() and use_gpu:
+            self.device = "mps"
         else:
             self.device = "cpu"
-        # self.device = "cpu"
 
     def process_image(self, image: np.ndarray, **kwargs) -> Dict[str, TrackedObject]:
         # "max_det=1" argument to limit to single person tracking for now
-        results = self.model(image, max_det=1, verbose=False, device=self.device)
+        results = self.model(image, max_det=1, verbose=True, device=self.device)
 
         self.unpack_results(results)
 
@@ -37,7 +37,10 @@ class YOLOPoseTracker(BaseTracker):
         return results[-1].plot()
 
     def unpack_results(self, results):
-        tracked_person = np.asarray(results[-1].keypoints.xy)
+        if self.device == "mps":
+            tracked_person = np.asarray(Tensor.cpu(results[-1].keypoints.xy))
+        else:
+            tracked_person = np.asarray(results[-1].keypoints.xy)
         self.tracked_objects["tracked_person"] = TrackedObject(
             object_id="tracked_person"
         )

--- a/skellytracker/utilities/get_video_paths.py
+++ b/skellytracker/utilities/get_video_paths.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+from typing import List, Union
+
+
+def get_video_paths(path_to_video_folder: Union[str, Path]) -> List[Path]:
+    """Search the folder for 'mp4' files (case insensitive) and return them as a list"""
+
+    list_of_video_paths = list(Path(path_to_video_folder).glob("*.mp4")) + list(
+        Path(path_to_video_folder).glob("*.MP4")
+    )
+    unique_list_of_video_paths = get_unique_list(list_of_video_paths)
+
+    return unique_list_of_video_paths
+
+
+def get_unique_list(list: list) -> list:
+    """Return a list of the unique elements from input list"""
+    unique_list = []
+    [unique_list.append(element) for element in list if element not in unique_list]
+
+    return unique_list


### PR DESCRIPTION
This PR patches two issues found in the `process_folder_of_videos` function:

1. Doing path searches with raw `.glob`: `.glob` behavior is not consistent between operating systems. It is case sensitive on Unix systems and not on Windows. This is fixes by replacing the raw `.glob` with an always case insensitive variant `get_video_paths`. 

2. Allowing too many processes to be created: When `num_processes = None`, the function was properly setting `num_processes` to be the minimum of the available processes and the number of videos in the recording folder. However when `num_processes` was passed in to the function as a parameter, no checks were done on the value. This PR makes it so we never attempt to spin up more processes than are available, or more than we have videos to process. This saves wasted resources creating processes that are not used.