### PR TITLE
Patch process_folder_of_videos

### DIFF
--- a/skellytracker/process_folder_of_videos.py
+++ b/skellytracker/process_folder_of_videos.py
@@ -21,6 +21,7 @@ from skellytracker.trackers.yolo_tracker.yolo_tracker import YOLOPoseTracker
 from skellytracker.trackers.mediapipe_tracker.mediapipe_model_info import (
     MediapipeTrackingParams,
 )
+from skellytracker.utilities.get_video_paths import get_video_paths
 
 logger = logging.getLogger(__name__)
 
@@ -52,10 +53,12 @@ def process_folder_of_videos(
     :param num_processes: Number of processes to use, 1 to disable multiprocessing.
     :return: Array of tracking data
     """
+    video_paths = get_video_paths(synchronized_video_path)
+
     if num_processes is None:
-        num_processes = min(
-            (cpu_count() - 1), len(list(synchronized_video_path.glob("*.mp4")))
-        )
+        num_processes = min((cpu_count() - 1), len(video_paths))
+    else:
+        num_processes = min(num_processes, len(video_paths), cpu_count() - 1)
 
     file_name = file_name_dictionary[tracker_name]
     synchronized_video_path = Path(synchronized_video_path)
@@ -75,7 +78,7 @@ def process_folder_of_videos(
 
     tasks = [
         (tracker_name, tracking_params, video_path, annotated_video_path)
-        for video_path in synchronized_video_path.glob("*.mp4")
+        for video_path in video_paths
     ]
 
     if num_processes > 1:

--- a/skellytracker/utilities/get_video_paths.py
+++ b/skellytracker/utilities/get_video_paths.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+from typing import List, Union
+
+
+def get_video_paths(path_to_video_folder: Union[str, Path]) -> List[Path]:
+    """Search the folder for 'mp4' files (case insensitive) and return them as a list"""
+
+    list_of_video_paths = list(Path(path_to_video_folder).glob("*.mp4")) + list(
+        Path(path_to_video_folder).glob("*.MP4")
+    )
+    unique_list_of_video_paths = get_unique_list(list_of_video_paths)
+
+    return unique_list_of_video_paths
+
+
+def get_unique_list(list: list) -> list:
+    """Return a list of the unique elements from input list"""
+    unique_list = []
+    [unique_list.append(element) for element in list if element not in unique_list]
+
+    return unique_list


### PR DESCRIPTION
This PR patches two issues found in the process_folder_of_videos function:

Doing path searches with raw .glob: .glob behavior is not consistent between operating systems. It is case sensitive on Unix systems and not on Windows. This is fixes by replacing the raw .glob with an always case insensitive variant get_video_paths.

Allowing too many processes to be created: When num_processes = None, the function was properly setting num_processes to be the minimum of the available processes and the number of videos in the recording folder. However when num_processes was passed in to the function as a parameter, no checks were done on the value. This PR makes it so we never attempt to spin up more processes than are available, or more than we have videos to process. This saves wasted resources creating processes that are not used.