### PR TITLE
Turn off static image mode as default

### DIFF
--- a/skellytracker/trackers/mediapipe_tracker/mediapipe_model_info.py
+++ b/skellytracker/trackers/mediapipe_tracker/mediapipe_model_info.py
@@ -34,4 +34,4 @@ class MediapipeTrackingParams(BaseTrackingParams):
     mediapipe_model_complexity: int = 2
     min_detection_confidence: float = 0.5
     min_tracking_confidence: float = 0.5
-    static_image_mode: bool = True
+    static_image_mode: bool = False


### PR DESCRIPTION
Minor PR to fix: https://github.com/freemocap/freemocap/issues/561

Changes MediaPipe default to not use static image mode. This makes MediaPipe use the previous frame's track as a starting point, which has lead to smoother trajectories in our testing. 