### PR TITLE
Patch Mediapipe skeleton ordering

### DIFF
--- a/skellytracker/trackers/mediapipe_tracker/mediapipe_model_info.py
+++ b/skellytracker/trackers/mediapipe_tracker/mediapipe_model_info.py
@@ -23,9 +23,9 @@ class MediapipeModelInfo:
     )
     mediapipe_tracked_object_names = [
         "pose_landmarks",
-        "face_landmarks",
         "left_hand_landmarks",
         "right_hand_landmarks",
+        "face_landmarks",
     ]
 
 

--- a/skellytracker/trackers/mediapipe_tracker/mediapipe_model_info.py
+++ b/skellytracker/trackers/mediapipe_tracker/mediapipe_model_info.py
@@ -23,8 +23,8 @@ class MediapipeModelInfo:
     )
     mediapipe_tracked_object_names = [
         "pose_landmarks",
-        "left_hand_landmarks",
         "right_hand_landmarks",
+        "left_hand_landmarks",
         "face_landmarks",
     ]
 


### PR DESCRIPTION
This fixes a bug in the mediapipe model info that was causing the mediapipe output array to be ordered incorrectly (pose, face, left hand, right hand). This fixes the ordering to (pose, right hand, left hand, face). This now matches Freemocap's ordering, and fixes the bugs we were having with hands in Blender.