### PR TITLE
Move tracker dependencies to extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,8 +57,6 @@ keywords = [
 dependencies = [
     "opencv-contrib-python==4.8.*",
     "pydantic==1.*",
-    "mediapipe==0.10.9",
-    "ultralytics~=8.0.202",
 ]
 requires-python = ">=3.9,<3.12"
 
@@ -66,6 +64,9 @@ dynamic = ["version", "description"]
 
 [project.optional-dependencies]
 dev = ["black", "bumpver", "isort", "pip-tools", "pytest"]
+mediapipe = ["mediapipe==0.10.9"]
+yolo = ["ultralytics~=8.0.202"]
+all = ["ultralytics~=8.0.202", "mediapipe==0.10.9"]
 
 [project.urls]
 Homepage = "https://github.com/freemocap/skellytracker"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ keywords = [
 dependencies = [
     "opencv-contrib-python==4.8.*",
     "pydantic==1.*",
+    "tqdm==4.*",
 ]
 requires-python = ">=3.9,<3.12"
 

--- a/skellytracker/RUN_ME.py
+++ b/skellytracker/RUN_ME.py
@@ -5,9 +5,6 @@ from skellytracker.trackers.bright_point_tracker.brightest_point_tracker import 
     BrightestPointTracker,
 )
 from skellytracker.trackers.charuco_tracker.charuco_tracker import CharucoTracker
-from skellytracker.trackers.segment_anything_tracker.segment_anything_tracker import (
-    SAMTracker,
-)
 try:
     from skellytracker.trackers.mediapipe_tracker.mediapipe_holistic_tracker import (
         MediapipeHolisticTracker,
@@ -18,6 +15,9 @@ try:
     from skellytracker.trackers.yolo_tracker.yolo_tracker import YOLOPoseTracker
     from skellytracker.trackers.yolo_object_tracker.yolo_object_tracker import (
         YOLOObjectTracker,
+    )
+    from skellytracker.trackers.segment_anything_tracker.segment_anything_tracker import (
+        SAMTracker,
     )
 except:
     print("To use yolo_tracker, install skellytracker[yolo]")

--- a/skellytracker/RUN_ME.py
+++ b/skellytracker/RUN_ME.py
@@ -1,19 +1,26 @@
 import cv2
 
+
 from skellytracker.trackers.bright_point_tracker.brightest_point_tracker import (
     BrightestPointTracker,
 )
 from skellytracker.trackers.charuco_tracker.charuco_tracker import CharucoTracker
-from skellytracker.trackers.mediapipe_tracker.mediapipe_holistic_tracker import (
-    MediapipeHolisticTracker,
-)
 from skellytracker.trackers.segment_anything_tracker.segment_anything_tracker import (
     SAMTracker,
 )
-from skellytracker.trackers.yolo_tracker.yolo_tracker import YOLOPoseTracker
-from skellytracker.trackers.yolo_object_tracker.yolo_object_tracker import (
-    YOLOObjectTracker,
-)
+try:
+    from skellytracker.trackers.mediapipe_tracker.mediapipe_holistic_tracker import (
+        MediapipeHolisticTracker,
+    )
+except:
+    print("To use mediapipe_holistic_tracker, install skellytracker[mediapipe]")
+try:
+    from skellytracker.trackers.yolo_tracker.yolo_tracker import YOLOPoseTracker
+    from skellytracker.trackers.yolo_object_tracker.yolo_object_tracker import (
+        YOLOObjectTracker,
+    )
+except:
+    print("To use yolo_tracker, install skellytracker[yolo]")
 
 
 def main(demo_tracker: str = "mediapipe_holistic_tracker"):

--- a/skellytracker/SINGLE_IMAGE_RUN.py
+++ b/skellytracker/SINGLE_IMAGE_RUN.py
@@ -15,7 +15,7 @@ except:
 try:
     from skellytracker.trackers.yolo_tracker.yolo_tracker import YOLOPoseTracker
 except:
-    print("To use yolo_tracker, install skellytracker[yolo]")
+    print("\n\nTo use yolo_tracker, install skellytracker[yolo]\n\n")
 
 
 if __name__ == "__main__":

--- a/skellytracker/SINGLE_IMAGE_RUN.py
+++ b/skellytracker/SINGLE_IMAGE_RUN.py
@@ -11,7 +11,7 @@ try:
         MediapipeHolisticTracker,
     )
 except:
-    print("To use mediapipe_holistic_tracker, install skellytracker[mediapipe]")
+    print("\n\nTo use mediapipe_holistic_tracker, install skellytracker[mediapipe]\n\n")
 try:
     from skellytracker.trackers.yolo_tracker.yolo_tracker import YOLOPoseTracker
 except:

--- a/skellytracker/SINGLE_IMAGE_RUN.py
+++ b/skellytracker/SINGLE_IMAGE_RUN.py
@@ -1,10 +1,22 @@
 import cv2
 from pathlib import Path
 
-from skellytracker.trackers.bright_point_tracker.brightest_point_tracker import BrightestPointTracker
+from skellytracker.trackers.bright_point_tracker.brightest_point_tracker import (
+    BrightestPointTracker,
+)
 from skellytracker.trackers.charuco_tracker.charuco_tracker import CharucoTracker
-from skellytracker.trackers.mediapipe_tracker.mediapipe_holistic_tracker import MediapipeHolisticTracker
-from skellytracker.trackers.yolo_tracker.yolo_tracker import YOLOPoseTracker
+
+try:
+    from skellytracker.trackers.mediapipe_tracker.mediapipe_holistic_tracker import (
+        MediapipeHolisticTracker,
+    )
+except:
+    print("To use mediapipe_holistic_tracker, install skellytracker[mediapipe]")
+try:
+    from skellytracker.trackers.yolo_tracker.yolo_tracker import YOLOPoseTracker
+except:
+    print("To use yolo_tracker, install skellytracker[yolo]")
+
 
 if __name__ == "__main__":
     demo_tracker = "brightest_point_tracker"
@@ -14,16 +26,20 @@ if __name__ == "__main__":
         BrightestPointTracker().image_demo(image_path=image_path)
 
     elif demo_tracker == "charuco_tracker":
-        CharucoTracker(squaresX=7,
-                       squaresY=5,
-                       dictionary=cv2.aruco.getPredefinedDictionary(cv2.aruco.DICT_4X4_250)).image_demo(image_path=image_path)
+        CharucoTracker(
+            squaresX=7,
+            squaresY=5,
+            dictionary=cv2.aruco.getPredefinedDictionary(cv2.aruco.DICT_4X4_250),
+        ).image_demo(image_path=image_path)
 
     elif demo_tracker == "mediapipe_holistic_tracker":
-        MediapipeHolisticTracker(model_complexity=2,
-                                 min_detection_confidence=0.5,
-                                 min_tracking_confidence=0.5,
-                                 static_image_mode=False,
-                                 smooth_landmarks=True).image_demo(image_path=image_path)
+        MediapipeHolisticTracker(
+            model_complexity=2,
+            min_detection_confidence=0.5,
+            min_tracking_confidence=0.5,
+            static_image_mode=False,
+            smooth_landmarks=True,
+        ).image_demo(image_path=image_path)
 
     elif demo_tracker == "yolo_tracker":
         YOLOPoseTracker(model_size="high_res").image_demo(image_path=image_path)

--- a/skellytracker/__init__.py
+++ b/skellytracker/__init__.py
@@ -23,9 +23,18 @@ sys.path.insert(0, str(base_package_path))  # add parent directory to sys.path
 from skellytracker.system.default_paths import get_log_file_path
 from skellytracker.system.logging_configuration import configure_logging
 
-from skellytracker.trackers.mediapipe_tracker.mediapipe_holistic_tracker import MediapipeHolisticTracker
-from skellytracker.trackers.yolo_tracker.yolo_tracker import YOLOPoseTracker
-from skellytracker.trackers.yolo_mediapipe_combo_tracker.yolo_mediapipe_combo_tracker import YOLOMediapipeComboTracker
+try:
+    from skellytracker.trackers.mediapipe_tracker.mediapipe_holistic_tracker import MediapipeHolisticTracker
+except:
+    print("To use mediapipe_holistic_tracker, install skellytracker[mediapipe]")
+try:
+    from skellytracker.trackers.yolo_tracker.yolo_tracker import YOLOPoseTracker
+except:
+    print("To use yolo_tracker, install skellytracker[yolo]")
+try:
+    from skellytracker.trackers.yolo_mediapipe_combo_tracker.yolo_mediapipe_combo_tracker import YOLOMediapipeComboTracker
+except:
+    print("To use yolo_mediapipe_combo_tracker, install skellytracker[mediapipe, yolo] or skellytracker[all]")
 
 
 

--- a/skellytracker/process_folder_of_videos.py
+++ b/skellytracker/process_folder_of_videos.py
@@ -20,6 +20,7 @@ except:
     print("To use yolo_mediapipe_combo_tracker, install skellytracker[yolo, mediapipe]")
 try:
     from skellytracker.trackers.yolo_tracker.yolo_tracker import YOLOPoseTracker
+    from skellytracker.trackers.yolo_tracker.yolo_model_info import YOLOTrackingParams
 except:
     print("To use yolo_tracker, install skellytracker[yolo]")
 try:
@@ -48,7 +49,7 @@ def process_folder_of_videos(
     synchronized_video_path: Path,
     output_folder_path: Optional[Path] = None,
     annotated_video_path: Optional[Path] = None,
-    num_processes: int = None,
+    num_processes: Optional[int] = None,
 ) -> np.ndarray:
     """
     Process a folder of synchronized videos with the given tracker.
@@ -176,6 +177,18 @@ def get_tracker(tracker_name: str, tracking_params: BaseModel) -> BaseTracker:
 
     return tracker
 
+def get_tracker_params(tracker_name: str) -> BaseModel:
+    if tracker_name == "MediapipeHolisticTracker":
+        return MediapipeTrackingParams()
+    elif tracker_name == "YOLOMediapipeComboTracker":
+        return YOLOTrackingParams()
+    elif tracker_name == "YOLOPoseTracker":
+        return YOLOTrackingParams()
+    elif tracker_name == "BrightestPointTracker":
+        return BaseModel()
+    else:
+        raise ValueError("Invalid tracker type")
+
 
 if __name__ == "__main__":
     synchronized_video_path = Path(
@@ -186,7 +199,7 @@ if __name__ == "__main__":
 
     process_folder_of_videos(
         tracker_name=tracker_name,
-        tracking_params=MediapipeTrackingParams(),
+        tracking_params=get_tracker_params(tracker_name=tracker_name),
         synchronized_video_path=synchronized_video_path,
         num_processes=num_processes,
     )

--- a/skellytracker/process_folder_of_videos.py
+++ b/skellytracker/process_folder_of_videos.py
@@ -2,7 +2,7 @@ import logging
 from multiprocessing import Pool, cpu_count
 from pathlib import Path
 import sys
-from typing import Any, Optional, Type
+from typing import Optional
 import numpy as np
 from pydantic import BaseModel
 
@@ -11,17 +11,26 @@ from skellytracker.trackers.base_tracker.base_tracker import BaseTracker
 from skellytracker.trackers.bright_point_tracker.brightest_point_tracker import (
     BrightestPointTracker,
 )
-from skellytracker.trackers.mediapipe_tracker.mediapipe_holistic_tracker import (
-    MediapipeHolisticTracker,
-)
-from skellytracker.trackers.yolo_mediapipe_combo_tracker.yolo_mediapipe_combo_tracker import (
-    YOLOMediapipeComboTracker,
-)
-from skellytracker.trackers.yolo_tracker.yolo_tracker import YOLOPoseTracker
-from skellytracker.trackers.mediapipe_tracker.mediapipe_model_info import (
-    MediapipeTrackingParams,
-)
 from skellytracker.utilities.get_video_paths import get_video_paths
+try:
+    from skellytracker.trackers.yolo_mediapipe_combo_tracker.yolo_mediapipe_combo_tracker import (
+        YOLOMediapipeComboTracker,
+    )
+except:
+    print("To use yolo_mediapipe_combo_tracker, install skellytracker[yolo, mediapipe]")
+try:
+    from skellytracker.trackers.yolo_tracker.yolo_tracker import YOLOPoseTracker
+except:
+    print("To use yolo_tracker, install skellytracker[yolo]")
+try:
+    from skellytracker.trackers.mediapipe_tracker.mediapipe_holistic_tracker import (
+        MediapipeHolisticTracker,
+    )
+    from skellytracker.trackers.mediapipe_tracker.mediapipe_model_info import (
+        MediapipeTrackingParams,
+    )
+except:
+    print("To use mediapipe_holistic_tracker, install skellytracker[mediapipe]")
 
 logger = logging.getLogger(__name__)
 

--- a/skellytracker/process_folder_of_videos.py
+++ b/skellytracker/process_folder_of_videos.py
@@ -17,7 +17,7 @@ try:
         YOLOMediapipeComboTracker,
     )
 except:
-    print("To use yolo_mediapipe_combo_tracker, install skellytracker[yolo, mediapipe]")
+    print("\n\nTo use yolo_mediapipe_combo_tracker, install skellytracker[yolo, mediapipe]\n\n")
 try:
     from skellytracker.trackers.yolo_tracker.yolo_tracker import YOLOPoseTracker
     from skellytracker.trackers.yolo_tracker.yolo_model_info import YOLOTrackingParams


### PR DESCRIPTION
Fixes #23.

Removes all of the pose estimators/tracking algorithms from the core dependencies and moves them into extras. Download options would be:

`pip install skellytracker` - just the core package
`pip install 'skellytracker[mediapipe]'` - core package and mediapipe
`pip install 'skellytracker[yolo]'` - core package and ultralytics (YOLO)
`pip install 'skellytracker[all]'` - core package, mediapipe, and ultralytics/YOLO

this is very easy to maintain and add to. Freemocap can just import [all] for now, but it gives us an option to change the download if ever include less commonly used trackers.

I've had to add conditional imports to files that download multiple trackers, but everything successfully runs. You can execute the `RUN_ME` and `process_folder_of_videos` in the limited install versions as long as you're using a tracker that's installed (e.g. missing YOLO doesn't throw an error when you try to run mediapipe).
