### PR TITLE
Patch: pass yolo crop tracking params into process folder of videos

### DIFF
--- a/skellytracker/process_folder_of_videos.py
+++ b/skellytracker/process_folder_of_videos.py
@@ -154,7 +154,7 @@ def get_tracker(tracker_name: str, tracking_params: BaseModel) -> BaseTracker:
             min_tracking_confidence=tracking_params.min_tracking_confidence,
             static_image_mode=True,  # yolo cropping must be run with static image mode due to changing size of bounding boxes
             bounding_box_buffer_percentage=tracking_params.bounding_box_buffer_percentage,
-            buffer_size_method=tracking_params.yolo_buffer_size_method,
+            buffer_size_method=tracking_params.buffer_size_method,
         )
 
     elif tracker_name == "YOLOPoseTracker":

--- a/skellytracker/process_folder_of_videos.py
+++ b/skellytracker/process_folder_of_videos.py
@@ -148,10 +148,13 @@ def get_tracker(tracker_name: str, tracking_params: BaseModel) -> BaseTracker:
 
     elif tracker_name == "YOLOMediapipeComboTracker":
         tracker = YOLOMediapipeComboTracker(
+            model_size=tracking_params.yolo_model_size,
             model_complexity=tracking_params.mediapipe_model_complexity,
             min_detection_confidence=tracking_params.min_detection_confidence,
             min_tracking_confidence=tracking_params.min_tracking_confidence,
             static_image_mode=True,  # yolo cropping must be run with static image mode due to changing size of bounding boxes
+            bounding_box_buffer_percentage=tracking_params.yolo_bounding_box_buffer_percentage,
+            buffer_size_method=tracking_params.yolo_buffer_size_method,
         )
 
     elif tracker_name == "YOLOPoseTracker":

--- a/skellytracker/process_folder_of_videos.py
+++ b/skellytracker/process_folder_of_videos.py
@@ -153,7 +153,7 @@ def get_tracker(tracker_name: str, tracking_params: BaseModel) -> BaseTracker:
             min_detection_confidence=tracking_params.min_detection_confidence,
             min_tracking_confidence=tracking_params.min_tracking_confidence,
             static_image_mode=True,  # yolo cropping must be run with static image mode due to changing size of bounding boxes
-            bounding_box_buffer_percentage=tracking_params.yolo_bounding_box_buffer_percentage,
+            bounding_box_buffer_percentage=tracking_params.bounding_box_buffer_percentage,
             buffer_size_method=tracking_params.yolo_buffer_size_method,
         )
 


### PR DESCRIPTION
Patch to ensure the yolo crop parameters are correctly passed into the `process_folder_of_videos` function.