### PR TITLE
Philip/support 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dynamic = ["version", "description"]
 dev = ["black", "bumpver", "isort", "pip-tools", "pytest"]
 mediapipe = ["mediapipe==0.10.14"]
 yolo = ["ultralytics~=8.0.202"]
-all = ["ultralytics~=8.0.202", "mediapipe==0.10.9"]
+all = ["ultralytics~=8.0.202", "mediapipe==0.10.14"]
 
 [project.urls]
 Homepage = "https://github.com/freemocap/skellytracker"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,13 +59,13 @@ dependencies = [
     "pydantic==1.*",
     "tqdm==4.*",
 ]
-requires-python = ">=3.9,<3.12"
+requires-python = ">=3.9,<3.13"
 
 dynamic = ["version", "description"]
 
 [project.optional-dependencies]
 dev = ["black", "bumpver", "isort", "pip-tools", "pytest"]
-mediapipe = ["mediapipe==0.10.9"]
+mediapipe = ["mediapipe==0.10.14"]
 yolo = ["ultralytics~=8.0.202"]
 all = ["ultralytics~=8.0.202", "mediapipe==0.10.9"]
 


### PR DESCRIPTION
Add support for Python 3.12. Includes updating to the latest mediapipe version.

See https://github.com/freemocap/freemocap/pull/609.