### PR TITLE
Patch yolo object cpu conversion

### DIFF
--- a/skellytracker/trackers/yolo_mediapipe_combo_tracker/yolo_mediapipe_combo_tracker.py
+++ b/skellytracker/trackers/yolo_mediapipe_combo_tracker/yolo_mediapipe_combo_tracker.py
@@ -55,7 +55,7 @@ class YOLOMediapipeComboTracker(BaseTracker):
     def process_image(self, image: np.ndarray, **kwargs) -> Dict[str, TrackedObject]:
 
         yolo_results = self.model(image, classes=0, max_det=1, verbose=False)
-        box_xyxy = np.asarray(yolo_results[0].boxes.xyxy).flatten()
+        box_xyxy = np.asarray(yolo_results[0].boxes.xyxy.cpu()).flatten()
 
         if box_xyxy.size > 0:
             box_left, box_top, box_right, box_bottom = box_xyxy

--- a/skellytracker/trackers/yolo_object_tracker/yolo_object_tracker.py
+++ b/skellytracker/trackers/yolo_object_tracker/yolo_object_tracker.py
@@ -32,7 +32,7 @@ class YOLOObjectTracker(BaseTracker):
     def process_image(self, image, **kwargs) -> Dict[str, TrackedObject]:
         results = self.model(image, classes=self.classes, max_det=1, verbose=False, conf=self.confidence_threshold)
 
-        box_xyxy = np.asarray(results[0].boxes.xyxy).flatten()
+        box_xyxy = np.asarray(results[0].boxes.xyxy.cpu()).flatten()  # if on GPU, need to copy to CPU before np array conversion
 
         if box_xyxy.size > 0:
             self.tracked_objects["object"].pixel_x = (box_xyxy[0] + box_xyxy[2]) / 0.5

--- a/skellytracker/trackers/yolo_object_tracker/yolo_object_tracker.py
+++ b/skellytracker/trackers/yolo_object_tracker/yolo_object_tracker.py
@@ -30,7 +30,7 @@ class YOLOObjectTracker(BaseTracker):
             self.classes = None
 
     def process_image(self, image, **kwargs) -> Dict[str, TrackedObject]:
-        results = self.model(image, classes=self.classes, max_det=1, verbose=False, conf=self.confidence_threshold)
+        results = self.model(image, classes=self.classes, device="cpu", max_det=1, verbose=False, conf=self.confidence_threshold)
 
         box_xyxy = np.asarray(results[0].boxes.xyxy.cpu()).flatten()  # if on GPU, need to copy to CPU before np array conversion
 

--- a/skellytracker/trackers/yolo_object_tracker/yolo_object_tracker.py
+++ b/skellytracker/trackers/yolo_object_tracker/yolo_object_tracker.py
@@ -30,7 +30,7 @@ class YOLOObjectTracker(BaseTracker):
             self.classes = None
 
     def process_image(self, image, **kwargs) -> Dict[str, TrackedObject]:
-        results = self.model(image, classes=self.classes, device="cpu", max_det=1, verbose=False, conf=self.confidence_threshold)
+        results = self.model(image, classes=self.classes, max_det=1, verbose=False, conf=self.confidence_threshold)
 
         box_xyxy = np.asarray(results[0].boxes.xyxy.cpu()).flatten()  # if on GPU, need to copy to CPU before np array conversion
 


### PR DESCRIPTION
The YOLO tracker is defaulting to CUDA when available, which is throwing an error when trying to convert the results tensor to a numpy array. This is easily fixed with a `.cpu()` call on the tensor before the conversion, which is simply skipped when running on cpu [per the documentation](https://pytorch.org/docs/stable/generated/torch.Tensor.cpu.html). 

This allows us to continue letting users with CUDA setup to get the benefits of their GPU