### PR TITLE
Refactor mediapipe process tracked objects

### DIFF
--- a/skellytracker/tests/test_mediapipe_holistic_tracker.py
+++ b/skellytracker/tests/test_mediapipe_holistic_tracker.py
@@ -122,3 +122,23 @@ def test_record(test_image):
     assert np.allclose(
         processed_results[:, :60, :], expected_results[:, :60, :], atol=1
     )
+
+@pytest.mark.usefixtures("test_image")
+def test_record_orders_correctly(test_image):
+    tracker = MediapipeHolisticTracker(model_complexity=0)
+    tracked_objects = tracker.process_image(test_image)
+    tracker.recorder.record(tracked_objects=tracked_objects)
+
+    processed_results = tracker.recorder.process_tracked_objects(
+        image_size=test_image.shape[:2]
+    )
+    body_points = MediapipeModelInfo.num_tracked_points_body
+    body_and_face_points = body_points + MediapipeModelInfo.num_tracked_points_face
+    body_face_and_left_hand_points = (
+        body_and_face_points
+        + MediapipeModelInfo.num_tracked_points_left_hand
+    )
+    assert np.allclose(processed_results[0, 0, :], [724.9490356445312, 80.74257552623749, -993.9854431152344], atol=1), "Body points are not ordered correctly"
+    assert np.allclose(processed_results[0, body_points, :], [253.68976593017578, 234.29851055145264, 0.0001452891228836961], atol=1), "Face points are not ordered correctly"
+    assert np.allclose(processed_results[0, body_and_face_points, :], [722.2523498535156, 89.31869745254517, -16.427509784698486], atol=1), "Left hand points are not ordered correctly"
+    assert np.allclose(processed_results[0, body_face_and_left_hand_points, :], [696.8218994140625, 81.22638165950775, -25.49912452697754], atol=1), "Right hand points are not ordered correctly"

--- a/skellytracker/tests/test_mediapipe_holistic_tracker.py
+++ b/skellytracker/tests/test_mediapipe_holistic_tracker.py
@@ -156,10 +156,6 @@ def test_record_missing_data(test_image):
         image_size=test_image.shape[:2]
     )
 
-    print(processed_results[:, :33, :].tolist())
-    print("\n\n\n")
-    print(processed_results[:, 33:75, :].tolist())
-
     assert not np.all(np.isnan(processed_results[:, :33, :])), "Body points incorrectly converted to NaN"
     assert np.all(np.isnan(processed_results[:, 33:54, :])), "Right hand points incorrectly converted to NaN"
     assert not np.all(np.isnan(processed_results[:, 54:75, :])), "Left hand points incorrectly converted to NaN"

--- a/skellytracker/tests/test_mediapipe_holistic_tracker.py
+++ b/skellytracker/tests/test_mediapipe_holistic_tracker.py
@@ -133,12 +133,34 @@ def test_record_orders_correctly(test_image):
         image_size=test_image.shape[:2]
     )
     body_points = MediapipeModelInfo.num_tracked_points_body
-    body_and_face_points = body_points + MediapipeModelInfo.num_tracked_points_face
-    body_face_and_left_hand_points = (
-        body_and_face_points
+    body_and_right_hand_points = body_points + MediapipeModelInfo.num_tracked_points_right_hand
+    body_and_both_hand_points = (
+        body_and_right_hand_points
         + MediapipeModelInfo.num_tracked_points_left_hand
     )
     assert np.allclose(processed_results[0, 0, :], [724.9490356445312, 80.74257552623749, -993.9854431152344], atol=1), "Body points are not ordered correctly"
-    assert np.allclose(processed_results[0, body_points, :], [253.68976593017578, 234.29851055145264, 0.0001452891228836961], atol=1), "Face points are not ordered correctly"
-    assert np.allclose(processed_results[0, body_and_face_points, :], [722.2523498535156, 89.31869745254517, -16.427509784698486], atol=1), "Left hand points are not ordered correctly"
-    assert np.allclose(processed_results[0, body_face_and_left_hand_points, :], [696.8218994140625, 81.22638165950775, -25.49912452697754], atol=1), "Right hand points are not ordered correctly"
+    assert np.allclose(processed_results[0, body_points, :], [253.68976593017578, 234.29851055145264, 0.0001452891228836961], atol=1), "Right hand points are not ordered correctly"
+    assert np.allclose(processed_results[0, body_and_right_hand_points, :], [831.35, 290.14, 0.00027009], atol=1), "Left hand points are not ordered correctly"
+    assert np.allclose(processed_results[0, body_and_both_hand_points, :], [688.53, 86.099, -14.351], atol=1), "Face points are not ordered correctly"
+
+@pytest.mark.usefixtures("test_image")
+def test_record_missing_data(test_image):
+    tracker = MediapipeHolisticTracker(model_complexity=0)
+    tracked_objects = tracker.process_image(test_image)
+    for object in tracked_objects.values():
+        if object.object_id == "right_hand_landmarks":
+            object.extra["landmarks"] = None
+    tracker.recorder.record(tracked_objects=tracked_objects)
+
+    processed_results = tracker.recorder.process_tracked_objects(
+        image_size=test_image.shape[:2]
+    )
+
+    print(processed_results[:, :33, :].tolist())
+    print("\n\n\n")
+    print(processed_results[:, 33:75, :].tolist())
+
+    assert not np.all(np.isnan(processed_results[:, :33, :])), "Body points incorrectly converted to NaN"
+    assert np.all(np.isnan(processed_results[:, 33:54, :])), "Right hand points incorrectly converted to NaN"
+    assert not np.all(np.isnan(processed_results[:, 54:75, :])), "Left hand points incorrectly converted to NaN"
+    assert not np.all(np.isnan(processed_results[:, 75:, :])), "Face points incorrectly converted to NaN"

--- a/skellytracker/trackers/base_tracker/base_tracker.py
+++ b/skellytracker/trackers/base_tracker/base_tracker.py
@@ -151,7 +151,7 @@ class BaseTracker(ABC):
         )
         camera_viewer.run()
 
-    def image_demo(self, image_path: Path) -> None:
+    def image_demo(self, image_path: Union[Path, str]) -> None:
         """
         Run tracker on single image
 
@@ -159,4 +159,4 @@ class BaseTracker(ABC):
         """
 
         image_viewer = ImageDemoViewer(self, self.__class__.__name__)
-        image_viewer.run(image_path=image_path)
+        image_viewer.run(image_path=Path(image_path))

--- a/skellytracker/trackers/image_demo_viewer/image_demo_viewer.py
+++ b/skellytracker/trackers/image_demo_viewer/image_demo_viewer.py
@@ -1,11 +1,12 @@
 from pathlib import Path
+from typing import Optional
 import cv2
 
 # Constants for key actions
 KEY_QUIT = ord("q")
 
 class ImageDemoViewer:
-    def __init__(self, tracker, window_title: str = None):
+    def __init__(self, tracker, window_title: Optional[str] = None):
         """
         Initialize with a tracker and optional window title and default exposure.
         """

--- a/skellytracker/trackers/mediapipe_tracker/mediapipe_holistic_recorder.py
+++ b/skellytracker/trackers/mediapipe_tracker/mediapipe_holistic_recorder.py
@@ -6,6 +6,7 @@ from skellytracker.trackers.base_tracker.base_recorder import BaseRecorder
 from skellytracker.trackers.base_tracker.tracked_object import TrackedObject
 from skellytracker.trackers.mediapipe_tracker.mediapipe_model_info import (
     MediapipeModelInfo,
+    MediapipeTrackedObjectNames
 )
 
 
@@ -61,10 +62,10 @@ class MediapipeHolisticRecorder(BaseRecorder):
             self.recorded_objects_array[i] = np.concatenate(
                 # this order matters, do not change
                 (
-                    frame_data["pose_landmarks"],
-                    frame_data["right_hand_landmarks"],
-                    frame_data["left_hand_landmarks"],
-                    frame_data["face_landmarks"],
+                    frame_data[MediapipeTrackedObjectNames.pose],
+                    frame_data[MediapipeTrackedObjectNames.right_hand],
+                    frame_data[MediapipeTrackedObjectNames.left_hand],
+                    frame_data[MediapipeTrackedObjectNames.face],
                 ),
                 axis=0,
             )
@@ -72,14 +73,14 @@ class MediapipeHolisticRecorder(BaseRecorder):
         return self.recorded_objects_array
 
     def num_tracked_points_by_name(self, name: str) -> int:
-        if name == "pose_landmarks":
+        if name == MediapipeTrackedObjectNames.pose:
             num_tracked_points = MediapipeModelInfo.num_tracked_points_body
-        elif name == "face_landmarks":
-            num_tracked_points = MediapipeModelInfo.num_tracked_points_face
-        elif name == "left_hand_landmarks":
-            num_tracked_points = MediapipeModelInfo.num_tracked_points_left_hand
-        elif name == "right_hand_landmarks":
+        elif name == MediapipeTrackedObjectNames.right_hand:
             num_tracked_points = MediapipeModelInfo.num_tracked_points_right_hand
+        elif name == MediapipeTrackedObjectNames.left_hand:
+            num_tracked_points = MediapipeModelInfo.num_tracked_points_left_hand
+        elif name == MediapipeTrackedObjectNames.face:
+            num_tracked_points = MediapipeModelInfo.num_tracked_points_face
         else:
             raise ValueError(
                 f"Invalid tracked object ID for mediapipe holistic tracker: {name}"

--- a/skellytracker/trackers/mediapipe_tracker/mediapipe_holistic_recorder.py
+++ b/skellytracker/trackers/mediapipe_tracker/mediapipe_holistic_recorder.py
@@ -6,7 +6,7 @@ from skellytracker.trackers.base_tracker.base_recorder import BaseRecorder
 from skellytracker.trackers.base_tracker.tracked_object import TrackedObject
 from skellytracker.trackers.mediapipe_tracker.mediapipe_model_info import (
     MediapipeModelInfo,
-    MediapipeTrackedObjectNames
+    MediapipeTrackedObjectNames,
 )
 
 
@@ -42,13 +42,13 @@ class MediapipeHolisticRecorder(BaseRecorder):
                 if recorded_object.extra["landmarks"] is None:
                     continue
 
-                landmarks = np.array([
-                    (landmark.x * image_size[0], 
-                    landmark.y * image_size[1], 
-                    landmark.z * image_size[0])
-                    for landmark in recorded_object.extra["landmarks"].landmark
-                ])
-                frame_data[recorded_object.object_id][:len(landmarks)] = landmarks
+                landmarks = np.array(
+                    [
+                        (landmark.x, landmark.y, landmark.z)
+                        for landmark in recorded_object.extra["landmarks"].landmark
+                    ]
+                )
+                frame_data[recorded_object.object_id][: len(landmarks)] = landmarks
 
             self.recorded_objects_array[i] = np.concatenate(
                 # this order matters, do not change
@@ -61,6 +61,8 @@ class MediapipeHolisticRecorder(BaseRecorder):
                 axis=0,
             )
 
+        # change from normalized image coordinates to pixel coordinates
+        self.recorded_objects_array *= np.array([image_size[0], image_size[1], image_size[0]])  # multiply z by image width per mediapipe docs
 
         return self.recorded_objects_array
 

--- a/skellytracker/trackers/mediapipe_tracker/mediapipe_holistic_recorder.py
+++ b/skellytracker/trackers/mediapipe_tracker/mediapipe_holistic_recorder.py
@@ -39,25 +39,21 @@ class MediapipeHolisticRecorder(BaseRecorder):
                 for name in MediapipeModelInfo.mediapipe_tracked_object_names
             }
             for recorded_object in recorded_object_list:
-                if recorded_object.extra["landmarks"] is not None:
-                    for j, landmark_data in enumerate(
-                        recorded_object.extra["landmarks"].landmark
-                    ):
-                        frame_data[recorded_object.object_id][j, 0] = (
-                            landmark_data.x * image_size[0]
-                        )
-                        frame_data[recorded_object.object_id][j, 1] = (
-                            landmark_data.y * image_size[1]
-                        )
-                        frame_data[recorded_object.object_id][j, 2] = (
-                            landmark_data.z * image_size[0]
-                        )  # multiply depth by image width, per MediaPipe documentation
+                if recorded_object.extra["landmarks"] is None:
+                    continue
 
-            for name in MediapipeModelInfo.mediapipe_tracked_object_names:
-                if name not in frame_data:
-                    frame_data[name] = np.full(
-                        self.num_tracked_points_by_name(name), np.nan
+                for j, landmark_data in enumerate(
+                    recorded_object.extra["landmarks"].landmark
+                ):
+                    frame_data[recorded_object.object_id][j, 0] = (
+                        landmark_data.x * image_size[0]
                     )
+                    frame_data[recorded_object.object_id][j, 1] = (
+                        landmark_data.y * image_size[1]
+                    )
+                    frame_data[recorded_object.object_id][j, 2] = (
+                        landmark_data.z * image_size[0]
+                    )  # multiply depth by image width, per MediaPipe documentation
 
             self.recorded_objects_array[i] = np.concatenate(
                 # this order matters, do not change

--- a/skellytracker/trackers/mediapipe_tracker/mediapipe_holistic_recorder.py
+++ b/skellytracker/trackers/mediapipe_tracker/mediapipe_holistic_recorder.py
@@ -33,101 +33,52 @@ class MediapipeHolisticRecorder(BaseRecorder):
         )
 
         for i, recorded_object_list in enumerate(self.recorded_objects):
-            frame_data = {}
+            frame_data = {
+                name: np.full((self.num_tracked_points_by_name(name), 3), np.nan)
+                for name in MediapipeModelInfo.mediapipe_tracked_object_names
+            }
             for recorded_object in recorded_object_list:
-                if recorded_object.object_id == "pose_landmarks":
-                    num_tracked_points = MediapipeModelInfo.num_tracked_points_body
-                elif recorded_object.object_id == "face_landmarks":
-                    num_tracked_points = MediapipeModelInfo.num_tracked_points_face
-                elif recorded_object.object_id == "left_hand_landmarks":
-                    num_tracked_points = MediapipeModelInfo.num_tracked_points_left_hand
-                elif recorded_object.object_id == "right_hand_landmarks":
-                    num_tracked_points = (
-                        MediapipeModelInfo.num_tracked_points_right_hand
-                    )
-                else:
-                    raise ValueError(
-                        f"Invalid tracked object ID for mediapipe holistic tracker: {recorded_object.object_id}"
-                    )
-                tracked_object_array = np.zeros((num_tracked_points, 3))
                 if recorded_object.extra["landmarks"] is not None:
                     for j, landmark_data in enumerate(
                         recorded_object.extra["landmarks"].landmark
                     ):
-                        tracked_object_array[j, 0] = landmark_data.x * image_size[0]
-                        tracked_object_array[j, 1] = landmark_data.y * image_size[1]
-                        tracked_object_array[j, 2] = (
+                        frame_data[recorded_object.object_id][j, 0] = landmark_data.x * image_size[0]
+                        frame_data[recorded_object.object_id][j, 1] = landmark_data.y * image_size[1]
+                        frame_data[recorded_object.object_id][j, 2] = (
                             landmark_data.z * image_size[0]
                         )  # multiply depth by image width, per MediaPipe documentation
-                else:
-                    tracked_object_array[:] = np.nan
 
-                frame_data[recorded_object.object_id] = tracked_object_array
-                print(tracked_object_array.shape)
+            for name in MediapipeModelInfo.mediapipe_tracked_object_names:
+                if name not in frame_data:
+                    frame_data[name] = np.full(
+                        self.num_tracked_points_by_name(name), np.nan
+                    )
 
             self.recorded_objects_array[i] = np.concatenate(
                 # this order matters, do not change
                 (
                     frame_data["pose_landmarks"],
-                    frame_data["face_landmarks"],
-                    frame_data["left_hand_landmarks"],
                     frame_data["right_hand_landmarks"],
+                    frame_data["left_hand_landmarks"],
+                    frame_data["face_landmarks"],
                 ),
                 axis=0,
             )
 
         return self.recorded_objects_array
-        
-    # def process_tracked_objects(self, **kwargs) -> np.ndarray:
-    #     image_size = kwargs.get("image_size")
-    #     if image_size is None:
-    #         raise ValueError(f"image_size must be provided to process tracked objects from {__class__.__name__}")
-    #     self.recorded_objects_array = np.zeros(
-    #         (
-    #             len(self.recorded_objects),
-    #             MediapipeModelInfo.num_tracked_points_total,
-    #             3,
-    #         )
-    #     )
 
-    #     for i, recorded_object_list in enumerate(self.recorded_objects):
-    #         landmark_number = 0
-    #         for recorded_object in recorded_object_list:
-    #             if recorded_object.extra["landmarks"] is not None:
-    #                 for landmark_data in recorded_object.extra["landmarks"].landmark:
-    #                     self.recorded_objects_array[i, landmark_number, 0] = (
-    #                         landmark_data.x * image_size[0]
-    #                     )
-    #                     self.recorded_objects_array[i, landmark_number, 1] = (
-    #                         landmark_data.y * image_size[1]
-    #                     )
-    #                     self.recorded_objects_array[i, landmark_number, 2] = (
-    #                         landmark_data.z * image_size[0]
-    #                     )  # * image width per mediapipe docs
-    #                     landmark_number += 1
-    #             else:
-    #                 if recorded_object.object_id == "pose_landmarks":
-    #                     number = MediapipeModelInfo.num_tracked_points_body
-    #                 elif recorded_object.object_id == "face_landmarks":
-    #                     number = MediapipeModelInfo.num_tracked_points_face
-    #                 elif recorded_object.object_id == "left_hand_landmarks":
-    #                     number = MediapipeModelInfo.num_tracked_points_left_hand
-    #                 else:
-    #                     number = MediapipeModelInfo.num_tracked_points_right_hand
-    #                 for _ in range(number):
-    #                     self.recorded_objects_array[i, landmark_number, :] = np.NaN
-    #                     landmark_number += 1
+    def num_tracked_points_by_name(self, name: str) -> int:
+        if name == "pose_landmarks":
+            num_tracked_points = MediapipeModelInfo.num_tracked_points_body
+        elif name == "face_landmarks":
+            num_tracked_points = MediapipeModelInfo.num_tracked_points_face
+        elif name == "left_hand_landmarks":
+            num_tracked_points = MediapipeModelInfo.num_tracked_points_left_hand
+        elif name == "right_hand_landmarks":
+            num_tracked_points = MediapipeModelInfo.num_tracked_points_right_hand
+        else:
+            raise ValueError(
+                f"Invalid tracked object ID for mediapipe holistic tracker: {name}"
+            )
 
-    #     return self.recorded_objects_array
-    
-if __name__ == "__main__":
-    array_1 = np.zeros((4, 3))
-    array_2 = np.full((3, 3), np.nan)
-
-    output = np.concatenate((array_1, array_2), axis=0)
-
-    print(output)
-
-    print(output.shape)
-
-    print(output[5, :])
+        return num_tracked_points

--- a/skellytracker/trackers/mediapipe_tracker/mediapipe_holistic_recorder.py
+++ b/skellytracker/trackers/mediapipe_tracker/mediapipe_holistic_recorder.py
@@ -42,8 +42,12 @@ class MediapipeHolisticRecorder(BaseRecorder):
                     for j, landmark_data in enumerate(
                         recorded_object.extra["landmarks"].landmark
                     ):
-                        frame_data[recorded_object.object_id][j, 0] = landmark_data.x * image_size[0]
-                        frame_data[recorded_object.object_id][j, 1] = landmark_data.y * image_size[1]
+                        frame_data[recorded_object.object_id][j, 0] = (
+                            landmark_data.x * image_size[0]
+                        )
+                        frame_data[recorded_object.object_id][j, 1] = (
+                            landmark_data.y * image_size[1]
+                        )
                         frame_data[recorded_object.object_id][j, 2] = (
                             landmark_data.z * image_size[0]
                         )  # multiply depth by image width, per MediaPipe documentation

--- a/skellytracker/trackers/mediapipe_tracker/mediapipe_holistic_recorder.py
+++ b/skellytracker/trackers/mediapipe_tracker/mediapipe_holistic_recorder.py
@@ -21,7 +21,9 @@ class MediapipeHolisticRecorder(BaseRecorder):
     def process_tracked_objects(self, **kwargs) -> np.ndarray:
         image_size = kwargs.get("image_size")
         if image_size is None:
-            raise ValueError(f"image_size must be provided to process tracked objects from {__class__.__name__}")
+            raise ValueError(
+                f"image_size must be provided to process tracked objects from {__class__.__name__}"
+            )
         self.recorded_objects_array = np.zeros(
             (
                 len(self.recorded_objects),
@@ -31,31 +33,101 @@ class MediapipeHolisticRecorder(BaseRecorder):
         )
 
         for i, recorded_object_list in enumerate(self.recorded_objects):
-            landmark_number = 0
+            frame_data = {}
             for recorded_object in recorded_object_list:
-                if recorded_object.extra["landmarks"] is not None:
-                    for landmark_data in recorded_object.extra["landmarks"].landmark:
-                        self.recorded_objects_array[i, landmark_number, 0] = (
-                            landmark_data.x * image_size[0]
-                        )
-                        self.recorded_objects_array[i, landmark_number, 1] = (
-                            landmark_data.y * image_size[1]
-                        )
-                        self.recorded_objects_array[i, landmark_number, 2] = (
-                            landmark_data.z * image_size[0]
-                        )  # * image width per mediapipe docs
-                        landmark_number += 1
+                if recorded_object.object_id == "pose_landmarks":
+                    num_tracked_points = MediapipeModelInfo.num_tracked_points_body
+                elif recorded_object.object_id == "face_landmarks":
+                    num_tracked_points = MediapipeModelInfo.num_tracked_points_face
+                elif recorded_object.object_id == "left_hand_landmarks":
+                    num_tracked_points = MediapipeModelInfo.num_tracked_points_left_hand
+                elif recorded_object.object_id == "right_hand_landmarks":
+                    num_tracked_points = (
+                        MediapipeModelInfo.num_tracked_points_right_hand
+                    )
                 else:
-                    if recorded_object.object_id == "pose_landmarks":
-                        number = MediapipeModelInfo.num_tracked_points_body
-                    elif recorded_object.object_id == "face_landmarks":
-                        number = MediapipeModelInfo.num_tracked_points_face
-                    elif recorded_object.object_id == "left_hand_landmarks":
-                        number = MediapipeModelInfo.num_tracked_points_left_hand
-                    else:
-                        number = MediapipeModelInfo.num_tracked_points_right_hand
-                    for _ in range(number):
-                        self.recorded_objects_array[i, landmark_number, :] = np.NaN
-                        landmark_number += 1
+                    raise ValueError(
+                        f"Invalid tracked object ID for mediapipe holistic tracker: {recorded_object.object_id}"
+                    )
+                tracked_object_array = np.zeros((num_tracked_points, 3))
+                if recorded_object.extra["landmarks"] is not None:
+                    for j, landmark_data in enumerate(
+                        recorded_object.extra["landmarks"].landmark
+                    ):
+                        tracked_object_array[j, 0] = landmark_data.x * image_size[0]
+                        tracked_object_array[j, 1] = landmark_data.y * image_size[1]
+                        tracked_object_array[j, 2] = (
+                            landmark_data.z * image_size[0]
+                        )  # multiply depth by image width, per MediaPipe documentation
+                else:
+                    tracked_object_array[:] = np.nan
+
+                frame_data[recorded_object.object_id] = tracked_object_array
+                print(tracked_object_array.shape)
+
+            self.recorded_objects_array[i] = np.concatenate(
+                # this order matters, do not change
+                (
+                    frame_data["pose_landmarks"],
+                    frame_data["face_landmarks"],
+                    frame_data["left_hand_landmarks"],
+                    frame_data["right_hand_landmarks"],
+                ),
+                axis=0,
+            )
 
         return self.recorded_objects_array
+        
+    # def process_tracked_objects(self, **kwargs) -> np.ndarray:
+    #     image_size = kwargs.get("image_size")
+    #     if image_size is None:
+    #         raise ValueError(f"image_size must be provided to process tracked objects from {__class__.__name__}")
+    #     self.recorded_objects_array = np.zeros(
+    #         (
+    #             len(self.recorded_objects),
+    #             MediapipeModelInfo.num_tracked_points_total,
+    #             3,
+    #         )
+    #     )
+
+    #     for i, recorded_object_list in enumerate(self.recorded_objects):
+    #         landmark_number = 0
+    #         for recorded_object in recorded_object_list:
+    #             if recorded_object.extra["landmarks"] is not None:
+    #                 for landmark_data in recorded_object.extra["landmarks"].landmark:
+    #                     self.recorded_objects_array[i, landmark_number, 0] = (
+    #                         landmark_data.x * image_size[0]
+    #                     )
+    #                     self.recorded_objects_array[i, landmark_number, 1] = (
+    #                         landmark_data.y * image_size[1]
+    #                     )
+    #                     self.recorded_objects_array[i, landmark_number, 2] = (
+    #                         landmark_data.z * image_size[0]
+    #                     )  # * image width per mediapipe docs
+    #                     landmark_number += 1
+    #             else:
+    #                 if recorded_object.object_id == "pose_landmarks":
+    #                     number = MediapipeModelInfo.num_tracked_points_body
+    #                 elif recorded_object.object_id == "face_landmarks":
+    #                     number = MediapipeModelInfo.num_tracked_points_face
+    #                 elif recorded_object.object_id == "left_hand_landmarks":
+    #                     number = MediapipeModelInfo.num_tracked_points_left_hand
+    #                 else:
+    #                     number = MediapipeModelInfo.num_tracked_points_right_hand
+    #                 for _ in range(number):
+    #                     self.recorded_objects_array[i, landmark_number, :] = np.NaN
+    #                     landmark_number += 1
+
+    #     return self.recorded_objects_array
+    
+if __name__ == "__main__":
+    array_1 = np.zeros((4, 3))
+    array_2 = np.full((3, 3), np.nan)
+
+    output = np.concatenate((array_1, array_2), axis=0)
+
+    print(output)
+
+    print(output.shape)
+
+    print(output[5, :])

--- a/skellytracker/trackers/mediapipe_tracker/mediapipe_holistic_recorder.py
+++ b/skellytracker/trackers/mediapipe_tracker/mediapipe_holistic_recorder.py
@@ -42,18 +42,13 @@ class MediapipeHolisticRecorder(BaseRecorder):
                 if recorded_object.extra["landmarks"] is None:
                     continue
 
-                for j, landmark_data in enumerate(
-                    recorded_object.extra["landmarks"].landmark
-                ):
-                    frame_data[recorded_object.object_id][j, 0] = (
-                        landmark_data.x * image_size[0]
-                    )
-                    frame_data[recorded_object.object_id][j, 1] = (
-                        landmark_data.y * image_size[1]
-                    )
-                    frame_data[recorded_object.object_id][j, 2] = (
-                        landmark_data.z * image_size[0]
-                    )  # multiply depth by image width, per MediaPipe documentation
+                landmarks = np.array([
+                    (landmark.x * image_size[0], 
+                    landmark.y * image_size[1], 
+                    landmark.z * image_size[0])
+                    for landmark in recorded_object.extra["landmarks"].landmark
+                ])
+                frame_data[recorded_object.object_id][:len(landmarks)] = landmarks
 
             self.recorded_objects_array[i] = np.concatenate(
                 # this order matters, do not change

--- a/skellytracker/trackers/mediapipe_tracker/mediapipe_holistic_tracker.py
+++ b/skellytracker/trackers/mediapipe_tracker/mediapipe_holistic_tracker.py
@@ -10,6 +10,7 @@ from skellytracker.trackers.mediapipe_tracker.mediapipe_holistic_recorder import
 )
 from skellytracker.trackers.mediapipe_tracker.mediapipe_model_info import (
     MediapipeModelInfo,
+    MediapipeTrackedObjectNames
 )
 
 
@@ -44,18 +45,19 @@ class MediapipeHolisticTracker(BaseTracker):
         results = self.holistic.process(rgb_image)
 
         # Update the tracking data
-        self.tracked_objects["pose_landmarks"].extra[
+        self.tracked_objects[MediapipeTrackedObjectNames.pose].extra[
             "landmarks"
         ] = results.pose_landmarks
-        self.tracked_objects["face_landmarks"].extra[
-            "landmarks"
-        ] = results.face_landmarks
-        self.tracked_objects["left_hand_landmarks"].extra[
-            "landmarks"
-        ] = results.left_hand_landmarks
-        self.tracked_objects["right_hand_landmarks"].extra[
+        self.tracked_objects[MediapipeTrackedObjectNames.right_hand].extra[
             "landmarks"
         ] = results.right_hand_landmarks
+        self.tracked_objects[MediapipeTrackedObjectNames.left_hand].extra[
+            "landmarks"
+        ] = results.left_hand_landmarks
+        self.tracked_objects[MediapipeTrackedObjectNames.face].extra[
+            "landmarks"
+        ] = results.face_landmarks
+
 
         self.annotated_image = self.annotate_image(
             image=image, tracked_objects=self.tracked_objects
@@ -70,23 +72,23 @@ class MediapipeHolisticTracker(BaseTracker):
         # Draw the pose, face, and hand landmarks on the image
         self.mp_drawing.draw_landmarks(
             annotated_image,
-            tracked_objects["pose_landmarks"].extra["landmarks"],
+            tracked_objects[MediapipeTrackedObjectNames.pose].extra["landmarks"],
             self.mp_holistic.POSE_CONNECTIONS,
         )
         self.mp_drawing.draw_landmarks(
             annotated_image,
-            tracked_objects["face_landmarks"].extra["landmarks"],
+            tracked_objects[MediapipeTrackedObjectNames.right_hand].extra["landmarks"],
+            self.mp_holistic.HAND_CONNECTIONS,
+        )
+        self.mp_drawing.draw_landmarks(
+            annotated_image,
+            tracked_objects[MediapipeTrackedObjectNames.left_hand].extra["landmarks"],
+            self.mp_holistic.HAND_CONNECTIONS,
+        )
+        self.mp_drawing.draw_landmarks(
+            annotated_image,
+            tracked_objects[MediapipeTrackedObjectNames.face].extra["landmarks"],
             self.mp_holistic.FACEMESH_TESSELATION,
-        )
-        self.mp_drawing.draw_landmarks(
-            annotated_image,
-            tracked_objects["left_hand_landmarks"].extra["landmarks"],
-            self.mp_holistic.HAND_CONNECTIONS,
-        )
-        self.mp_drawing.draw_landmarks(
-            annotated_image,
-            tracked_objects["right_hand_landmarks"].extra["landmarks"],
-            self.mp_holistic.HAND_CONNECTIONS,
         )
 
         return annotated_image

--- a/skellytracker/trackers/mediapipe_tracker/mediapipe_model_info.py
+++ b/skellytracker/trackers/mediapipe_tracker/mediapipe_model_info.py
@@ -11,6 +11,12 @@ mediapipe_hand_landmark_names = [
     landmark.name.lower() for landmark in mp_holistic.HandLandmark
 ]
 
+class MediapipeTrackedObjectNames:
+    pose = "pose_landmarks"
+    right_hand = "right_hand_landmarks"
+    left_hand = "left_hand_landmarks"
+    face = "face_landmarks"
+
 
 class MediapipeModelInfo:
     num_tracked_points_body = len(mediapipe_body_landmark_names)
@@ -23,10 +29,10 @@ class MediapipeModelInfo:
         + FACEMESH_NUM_LANDMARKS_WITH_IRISES
     )
     mediapipe_tracked_object_names = [
-        "pose_landmarks",
-        "right_hand_landmarks",
-        "left_hand_landmarks",
-        "face_landmarks",
+        MediapipeTrackedObjectNames.pose,
+        MediapipeTrackedObjectNames.right_hand,
+        MediapipeTrackedObjectNames.left_hand,
+        MediapipeTrackedObjectNames.face,
     ]
 
 

--- a/skellytracker/trackers/yolo_mediapipe_combo_tracker/yolo_mediapipe_combo_tracker.py
+++ b/skellytracker/trackers/yolo_mediapipe_combo_tracker/yolo_mediapipe_combo_tracker.py
@@ -13,6 +13,7 @@ from skellytracker.trackers.mediapipe_tracker.mediapipe_holistic_recorder import
 )
 from skellytracker.trackers.mediapipe_tracker.mediapipe_model_info import (
     MediapipeModelInfo,
+    MediapipeTrackedObjectNames
 )
 from skellytracker.trackers.yolo_object_tracker.yolo_object_model_info import (
     yolo_object_model_dictionary,
@@ -104,18 +105,19 @@ class YOLOMediapipeComboTracker(BaseTracker):
         self._rescale_cropped_data(
             image, box_left, box_top, box_right, box_bottom, mediapipe_results
         )
-        self.tracked_objects["pose_landmarks"].extra[
+        self.tracked_objects[MediapipeTrackedObjectNames.pose].extra[
             "landmarks"
         ] = mediapipe_results.pose_landmarks
-        self.tracked_objects["face_landmarks"].extra[
-            "landmarks"
-        ] = mediapipe_results.face_landmarks
-        self.tracked_objects["left_hand_landmarks"].extra[
-            "landmarks"
-        ] = mediapipe_results.left_hand_landmarks
-        self.tracked_objects["right_hand_landmarks"].extra[
+        self.tracked_objects[MediapipeTrackedObjectNames.right_hand].extra[
             "landmarks"
         ] = mediapipe_results.right_hand_landmarks
+        self.tracked_objects[MediapipeTrackedObjectNames.left_hand].extra[
+            "landmarks"
+        ] = mediapipe_results.left_hand_landmarks
+        self.tracked_objects[MediapipeTrackedObjectNames.face].extra[
+            "landmarks"
+        ] = mediapipe_results.face_landmarks
+
 
         bbox_image = buffered_yolo_results[0].plot()
 
@@ -194,23 +196,23 @@ class YOLOMediapipeComboTracker(BaseTracker):
         # Draw the pose, face, and hand landmarks on the image
         self.mp_drawing.draw_landmarks(
             image,
-            tracked_objects["pose_landmarks"].extra["landmarks"],
+            tracked_objects[MediapipeTrackedObjectNames.pose].extra["landmarks"],
             self.mp_holistic.POSE_CONNECTIONS,
         )
         self.mp_drawing.draw_landmarks(
             image,
-            tracked_objects["face_landmarks"].extra["landmarks"],
+            tracked_objects[MediapipeTrackedObjectNames.right_hand].extra["landmarks"],
+            self.mp_holistic.HAND_CONNECTIONS,
+        )
+        self.mp_drawing.draw_landmarks(
+            image,
+            tracked_objects[MediapipeTrackedObjectNames.left_hand].extra["landmarks"],
+            self.mp_holistic.HAND_CONNECTIONS,
+        )
+        self.mp_drawing.draw_landmarks(
+            image,
+            tracked_objects[MediapipeTrackedObjectNames.face].extra["landmarks"],
             self.mp_holistic.FACEMESH_TESSELATION,
-        )
-        self.mp_drawing.draw_landmarks(
-            image,
-            tracked_objects["left_hand_landmarks"].extra["landmarks"],
-            self.mp_holistic.HAND_CONNECTIONS,
-        )
-        self.mp_drawing.draw_landmarks(
-            image,
-            tracked_objects["right_hand_landmarks"].extra["landmarks"],
-            self.mp_holistic.HAND_CONNECTIONS,
         )
 
         return image


### PR DESCRIPTION
Heavily simplify the logic in the `process_tracked_objects` function in the Mediapipe Holistic recorder. 

The prior iteration used some complicated numerical indexing that was hard for me to follow and seemed very difficult to maintain (or even verify for correctness). So I wrote a few more tests and then refactored the function to be easier to understand. Now it makes an array for each type of landmark (pose, hands, face) and then concatenates the arrays in the proper order. I also added a comment to not change that order. The prior version was dependent on receiving the tracked objects in the correct order.