### PR TITLE
Make annotate images optional

### DIFF
--- a/skellytracker/trackers/base_tracker/base_tracker.py
+++ b/skellytracker/trackers/base_tracker/base_tracker.py
@@ -37,11 +37,12 @@ class BaseTracker(ABC):
             self.tracked_objects[name] = TrackedObject(object_id=name)
 
     @abstractmethod
-    def process_image(self, image: np.ndarray, **kwargs) -> Dict[str, TrackedObject]:
+    def process_image(self, image: np.ndarray, annotate_image: bool = True, **kwargs) -> Dict[str, TrackedObject]:
         """
         Process the input image and apply the tracking algorithm.
 
         :param image: An input image.
+        :param annotate_image: Whether to annotate a copy of the image with the results of the tracking algorithm.
         :return: A dictionary of tracked objects
         """
         pass

--- a/skellytracker/trackers/charuco_tracker/charuco_tracker.py
+++ b/skellytracker/trackers/charuco_tracker/charuco_tracker.py
@@ -10,6 +10,7 @@ from skellytracker.trackers.charuco_tracker.charuco_recorder import CharucoRecor
 
 default_aruco_dictionary = cv2.aruco.getPredefinedDictionary(cv2.aruco.DICT_4X4_250)
 
+
 class CharucoTracker(BaseTracker):
     def __init__(
         self,
@@ -36,7 +37,9 @@ class CharucoTracker(BaseTracker):
         self.tracked_object_names = tracked_object_names
         self.dictionary = dictionary
 
-    def process_image(self, image: np.ndarray, **kwargs) -> Dict[str, TrackedObject]:
+    def process_image(
+        self, image: np.ndarray, annotate_image: bool = True, **kwargs
+    ) -> Dict[str, TrackedObject]:
         # Convert the image to grayscale
         gray_image = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
 
@@ -59,9 +62,10 @@ class CharucoTracker(BaseTracker):
                 self.tracked_objects[object_id].pixel_x = corner[0][0]
                 self.tracked_objects[object_id].pixel_y = corner[0][1]
 
-        self.annotated_image = self.annotate_image(
-            image=image, tracked_objects=self.tracked_objects
-        )
+        if annotate_image:
+            self.annotated_image = self.annotate_image(
+                image=image, tracked_objects=self.tracked_objects
+            )
 
         return self.tracked_objects
 

--- a/skellytracker/trackers/mediapipe_blendshape_tracker/mediapipe_blendshape_tracker.py
+++ b/skellytracker/trackers/mediapipe_blendshape_tracker/mediapipe_blendshape_tracker.py
@@ -46,7 +46,9 @@ class MediapipeBlendshapeTracker(BaseTracker):
         )
         self.detector = vision.FaceLandmarker.create_from_options(options)
 
-    def process_image(self, image: np.ndarray, **kwargs) -> Dict[str, TrackedObject]:
+    def process_image(
+        self, image: np.ndarray, annotate_image: bool = True, **kwargs
+    ) -> Dict[str, TrackedObject]:
         rgb_image = cv2.cvtColor(
             image, cv2.COLOR_BGR2RGB
         )  # TODO: may need to convert this into an `mp.Image`, but can't find documentation about that
@@ -63,11 +65,12 @@ class MediapipeBlendshapeTracker(BaseTracker):
             blendshape.score for blendshape in results.face_blendshapes[0]
         ]  # TODO: assumes we're only interested in 1 face, but docs say this works for multiple faces??
 
-        self.annotated_image = self.annotate_image(
-            image=image,
-            tracked_objects=self.tracked_objects,
-            face_landmarks=results.face_landmarks[0],
-        )
+        if annotate_image:
+            self.annotated_image = self.annotate_image(
+                image=image,
+                tracked_objects=self.tracked_objects,
+                face_landmarks=results.face_landmarks[0],
+            )
 
         return self.tracked_objects
 
@@ -127,7 +130,7 @@ class MediapipeBlendshapeTracker(BaseTracker):
             r.raise_for_status()
             model_path.write_bytes(r.content)
         return model_path
-    
+
 
 if __name__ == "__main__":
     MediapipeBlendshapeTracker().demo()

--- a/skellytracker/trackers/mediapipe_tracker/mediapipe_holistic_tracker.py
+++ b/skellytracker/trackers/mediapipe_tracker/mediapipe_holistic_tracker.py
@@ -36,7 +36,9 @@ class MediapipeHolisticTracker(BaseTracker):
             smooth_landmarks=smooth_landmarks,
         )
 
-    def process_image(self, image: np.ndarray, **kwargs) -> Dict[str, TrackedObject]:
+    def process_image(
+        self, image: np.ndarray, annotate_image: bool = True, **kwargs
+    ) -> Dict[str, TrackedObject]:
         # Convert the image to RGB
         rgb_image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
 
@@ -57,9 +59,10 @@ class MediapipeHolisticTracker(BaseTracker):
             "landmarks"
         ] = results.right_hand_landmarks
 
-        self.annotated_image = self.annotate_image(
-            image=image, tracked_objects=self.tracked_objects
-        )
+        if annotate_image:
+            self.annotated_image = self.annotate_image(
+                image=image, tracked_objects=self.tracked_objects
+            )
 
         return self.tracked_objects
 

--- a/skellytracker/trackers/yolo_mediapipe_combo_tracker/yolo_mediapipe_combo_tracker.py
+++ b/skellytracker/trackers/yolo_mediapipe_combo_tracker/yolo_mediapipe_combo_tracker.py
@@ -52,7 +52,9 @@ class YOLOMediapipeComboTracker(BaseTracker):
         self.bounding_box_buffer_percentage = bounding_box_buffer_percentage
         self.buffer_size_method = buffer_size_method
 
-    def process_image(self, image: np.ndarray, **kwargs) -> Dict[str, TrackedObject]:
+    def process_image(
+        self, image: np.ndarray, annotate_image: bool = True, **kwargs
+    ) -> Dict[str, TrackedObject]:
 
         yolo_results = self.model(image, classes=0, max_det=1, verbose=False)
         box_xyxy = np.asarray(yolo_results[0].boxes.xyxy.cpu()).flatten()
@@ -119,9 +121,10 @@ class YOLOMediapipeComboTracker(BaseTracker):
 
         bbox_image = buffered_yolo_results[0].plot()
 
-        self.annotated_image = self.annotate_image(
-            image=bbox_image, tracked_objects=self.tracked_objects
-        )
+        if annotate_image:
+            self.annotated_image = self.annotate_image(
+                image=bbox_image, tracked_objects=self.tracked_objects
+            )
 
         return self.tracked_objects
 

--- a/skellytracker/trackers/yolo_object_tracker/yolo_object_tracker.py
+++ b/skellytracker/trackers/yolo_object_tracker/yolo_object_tracker.py
@@ -31,7 +31,9 @@ class YOLOObjectTracker(BaseTracker):
         else:
             self.classes = None  # None includes all classes
 
-    def process_image(self, image, **kwargs) -> Dict[str, TrackedObject]:
+    def process_image(
+        self, image, annotate_image: bool = True, **kwargs
+    ) -> Dict[str, TrackedObject]:
         results = self.model(
             image,
             classes=self.classes,
@@ -53,7 +55,8 @@ class YOLOObjectTracker(BaseTracker):
             0
         ].boxes.orig_shape
 
-        self.annotated_image = self.annotate_image(image, results=results, **kwargs)
+        if annotate_image:
+            self.annotated_image = self.annotate_image(image, results=results, **kwargs)
 
         return self.tracked_objects
 

--- a/skellytracker/trackers/yolo_tracker/yolo_tracker.py
+++ b/skellytracker/trackers/yolo_tracker/yolo_tracker.py
@@ -15,15 +15,18 @@ class YOLOPoseTracker(BaseTracker):
         pytorch_model = YOLOModelInfo.model_dictionary[model_size]
         self.model = YOLO(pytorch_model)
 
-    def process_image(self, image: np.ndarray, **kwargs) -> Dict[str, TrackedObject]:
+    def process_image(
+        self, image: np.ndarray, annotate_image: bool = True, **kwargs
+    ) -> Dict[str, TrackedObject]:
         # "max_det=1" argument to limit to single person tracking for now
         results = self.model(image, max_det=1, verbose=False)
 
         self.unpack_results(results)
 
-        self.annotated_image = self.annotate_image(
-            image=image, results=results, **kwargs
-        )
+        if annotate_image:
+            self.annotated_image = self.annotate_image(
+                image=image, results=results, **kwargs
+            )
 
         return self.tracked_objects
 


### PR DESCRIPTION
Adds a flag in the `process_videos` function to make annotating images optional. 

This saves time at the cost of observability, but that's a tradeoff we may want to make during realtime processing. It is also possible to make drawing functions that don't need to happen during the original processing, if there is a need for analyzing issues in realtime processing after the fact. 

Currently the flag is set in `process_videos` but not exposed in `process_folder_of_videos`, as its intended use is for realtime processing. It could also be a flag set tracker-wide rather in the function call. 