### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,13 @@ yolo = ["ultralytics~=8.0.202"]
 dlc = ["deeplabcut==3.0.0rc9", "pillow>=11.1.0", "pyyaml>=6.0.2"]
 all = ["ultralytics~=8.0.202", "mediapipe==0.10.14"]
 
+[project.optional-dependencies]
+dev = ["black", "bumpver", "isort", "pip-tools", "pytest", "ruff"]
+mediapipe = ["mediapipe==0.10.14"]
+yolo = ["ultralytics~=8.0.202"]
+dlc = ["deeplabcut==3.0.0rc9", "pillow>=11.1.0", "pyyaml>=6.0.2"]
+all = ["ultralytics~=8.0.202", "mediapipe==0.10.14"]
+
 [project.urls]
 Homepage = "https://github.com/freemocap/skellytracker"
 


### PR DESCRIPTION
Fix to let you `uv pip install "skellytracker[mediapipe] @ git+https:....` which wasn't working prior