### PR TITLE
fix(io): read YAML configuration files as UTF-8

### DIFF
--- a/skellytracker/core/detectors/keypoint_detectors/_schema_loader.py
+++ b/skellytracker/core/detectors/keypoint_detectors/_schema_loader.py
@@ -6,12 +6,12 @@ import yaml
 
 
 def load_point_names(path: Path) -> tuple[str, ...]:
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         data = yaml.safe_load(f)
     return tuple(data["tracked_points"])
 
 
 def load_connections(path: Path) -> tuple[tuple[str, str], ...]:
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         data = yaml.safe_load(f)
     return tuple((a, b) for a, b in data.get("connections", []))

--- a/skellytracker/core/io/tracker_mapping.py
+++ b/skellytracker/core/io/tracker_mapping.py
@@ -106,7 +106,7 @@ class TrackerMapping:
             produces ``right_hand_root`` but the mapping defines
             ``root`` → ``wrist``.
         """
-        with open(yaml_path, "r") as fh:
+        with open(yaml_path, "r", encoding="utf-8") as fh:
             data = yaml.safe_load(fh)
         if not isinstance(data, dict):
             raise TypeError(

--- a/skellytracker/tests/test_schema_loader.py
+++ b/skellytracker/tests/test_schema_loader.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import builtins
+from pathlib import Path
+from typing import Any
+
+from skellytracker.core.detectors.keypoint_detectors._schema_loader import (
+    load_connections,
+    load_point_names,
+)
+from skellytracker.core.io.tracker_mapping import TrackerMapping
+
+
+def test_schema_loaders_use_utf8_on_a_gbk_default_system(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    schema_path = tmp_path / "模型定义.yaml"
+    schema_path.write_text(
+        "# 中文注释用于模拟 Windows 简体中文环境\n"
+        "tracked_points:\n"
+        "  - left_hip\n"
+        "  - right_hip\n"
+        "connections:\n"
+        "  - [left_hip, right_hip]\n",
+        encoding="utf-8",
+    )
+
+    real_open = builtins.open
+
+    def open_with_gbk_default(*args: Any, **kwargs: Any) -> Any:
+        kwargs.setdefault("encoding", "gbk")
+        return real_open(*args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", open_with_gbk_default)
+
+    assert load_point_names(schema_path) == ("left_hip", "right_hip")
+    assert load_connections(schema_path) == (("left_hip", "right_hip"),)
+
+
+def test_tracker_mapping_uses_utf8_on_a_gbk_default_system(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    mapping_path = tmp_path / "映射定义.yaml"
+    mapping_path.write_text(
+        "# 中文注释用于模拟 Windows 简体中文环境\n"
+        "hips_center: [left_hip, right_hip]\n",
+        encoding="utf-8",
+    )
+
+    real_open = builtins.open
+
+    def open_with_gbk_default(*args: Any, **kwargs: Any) -> Any:
+        kwargs.setdefault("encoding", "gbk")
+        return real_open(*args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", open_with_gbk_default)
+
+    mapping = TrackerMapping.from_yaml(mapping_path)
+
+    assert mapping.canonical_names == ["hips_center"]


### PR DESCRIPTION
## Summary

- open detector schema YAML files with an explicit UTF-8 encoding
- open tracker-mapping YAML files with an explicit UTF-8 encoding
- add Windows regression coverage that simulates a GBK/CP936 default code page

This keeps model configuration loading independent of the operating-system locale and does not change the public API or file format.

## Tests

- `pytest skellytracker/tests/test_schema_loader.py -q` — 2 passed
- exercised under the FreeMoCap Python 3.11 Windows build environment