### PR TITLE
feat: stabilize two-person temporal tracking

### DIFF
--- a/.github/workflows/mivubi-multi-person.yml
+++ b/.github/workflows/mivubi-multi-person.yml
@@ -1,0 +1,29 @@
+name: Mivubi multi-person regression
+
+on:
+  push:
+    branches: [feature/mivubi-multi-person]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.12.5"
+          enable-cache: true
+      - run: uv sync --frozen --extra all-cpu
+      - run: uv run ruff check skellytracker/
+      - run: >-
+          uv run pytest -q
+          skellytracker/tests/test_track_association.py
+          skellytracker/tests/test_multi_person_tracker.py
+          skellytracker/tests/test_temporal_processing.py
+          skellytracker/tests/test_keypoints.py
+          skellytracker/tests/test_precomputed_object_detector.py

--- a/skellytracker/core/temporal_processing/multi_person_config.py
+++ b/skellytracker/core/temporal_processing/multi_person_config.py
@@ -31,3 +31,5 @@ class MultiPersonTrackingConfig(BaseModel):
     max_match_cost: float = 0.8
     max_age: int = 10
     min_hits: int = 3
+    max_persons: int = 2
+    ambiguity_margin: float = 0.08

--- a/skellytracker/core/temporal_processing/track_association.py
+++ b/skellytracker/core/temporal_processing/track_association.py
@@ -121,6 +121,7 @@ class AssociationResult:
     matches: list[tuple[int, int]]
     unmatched_tracks: list[int]
     unmatched_detections: list[int]
+    held_detections: list[int]
 
 
 def associate(
@@ -143,6 +144,7 @@ def associate(
             matches=[],
             unmatched_tracks=list(range(n_tracks)),
             unmatched_detections=list(range(n_dets)),
+            held_detections=[],
         )
 
     cost = combined_cost_matrix(track_bboxes, track_keypoints, det_bboxes, det_keypoints, config)
@@ -156,16 +158,31 @@ def associate(
     matches: list[tuple[int, int]] = []
     matched_tracks: set[int] = set()
     matched_dets: set[int] = set()
+    held_dets: set[int] = set()
     for t, d in zip(track_idx, det_idx, strict=False):
-        if cost[t, d] <= config.max_match_cost:
+        alternatives = np.delete(cost[t], d)
+        finite_alternatives = alternatives[np.isfinite(alternatives)]
+        ambiguous = (
+            finite_alternatives.size > 0
+            and float(finite_alternatives.min() - cost[t, d]) < config.ambiguity_margin
+        )
+        if ambiguous:
+            # Reserve this detection for the frame, but hold the existing
+            # track instead of accepting a low-confidence identity decision
+            # or spawning a duplicate track during a crossing.
+            held_dets.add(int(d))
+        elif cost[t, d] <= config.max_match_cost:
             matches.append((int(t), int(d)))
             matched_tracks.add(int(t))
             matched_dets.add(int(d))
 
     unmatched_tracks = [t for t in range(n_tracks) if t not in matched_tracks]
-    unmatched_detections = [d for d in range(n_dets) if d not in matched_dets]
+    unmatched_detections = [
+        d for d in range(n_dets) if d not in matched_dets and d not in held_dets
+    ]
     return AssociationResult(
         matches=matches,
         unmatched_tracks=unmatched_tracks,
         unmatched_detections=unmatched_detections,
+        held_detections=sorted(held_dets),
     )

--- a/skellytracker/core/tracker/multi_person_tracker.py
+++ b/skellytracker/core/tracker/multi_person_tracker.py
@@ -71,7 +71,11 @@ class MultiPersonTracker:
         root = self.stages[0]
 
         # 1. Propose candidate person boxes for the whole frame.
-        candidate_bboxes = root.object_detector.detect(image, context)
+        candidate_bboxes = sorted(
+            root.object_detector.detect(image, context),
+            key=lambda bbox: bbox.confidence,
+            reverse=True,
+        )[: self.multi_person_config.max_persons]
 
         # 2. Run keypoint detection per candidate, independent of identity —
         # every downstream stage (root + children) computes raw detections,
@@ -86,7 +90,7 @@ class MultiPersonTracker:
 
         # 3. Associate this frame's candidates against existing tracks.
         track_ids = list(tracks.keys())
-        track_bboxes: list[BoundingBox | None] = [tracks[tid].last_bbox for tid in track_ids]
+        track_bboxes: list[BoundingBox | None] = [tracks[tid].predicted_bbox() for tid in track_ids]
         track_keypoints: list[Keypoints | None] = [tracks[tid].last_keypoints for tid in track_ids]
         result = associate(
             track_bboxes, track_keypoints, candidate_bboxes, candidate_keypoints, self.multi_person_config
@@ -100,6 +104,8 @@ class MultiPersonTracker:
 
         # 5. Unmatched detections: spawn new tracks.
         for det_idx in result.unmatched_detections:
+            if len(tracks) >= self.multi_person_config.max_persons:
+                continue
             track_id = self._next_track_id
             self._next_track_id += 1
             track = PersonTrackState(track_id=track_id)
@@ -158,7 +164,9 @@ class MultiPersonTracker:
             obs, updated_state = stage.finalize_track(raw, state, context)
             track.stage_states[stage.name] = updated_state
             if stage.name == self.stages[0].name:
-                track.last_bbox = obs.bounding_boxes[0] if obs.bounding_boxes else raw.bbox
+                next_bbox = obs.bounding_boxes[0] if obs.bounding_boxes else raw.bbox
+                track.update_motion(next_bbox)
+                track.last_bbox = next_bbox
                 track.last_keypoints = obs.keypoints
             for child in stage.children:
                 _recurse(child)

--- a/skellytracker/core/tracker/person_track.py
+++ b/skellytracker/core/tracker/person_track.py
@@ -24,6 +24,30 @@ class PersonTrackState:
     hits: int = 0
     time_since_update: int = 0
     age: int = 0
+    center_velocity: tuple[float, float] = (0.0, 0.0)
 
     def confirmed(self, min_hits: int) -> bool:
         return self.hits >= min_hits
+
+    def predicted_bbox(self) -> BoundingBox | None:
+        """Constant-velocity prediction used before Hungarian association."""
+        if self.last_bbox is None:
+            return None
+        dx, dy = self.center_velocity
+        return BoundingBox(
+            x1=self.last_bbox.x1 + dx,
+            y1=self.last_bbox.y1 + dy,
+            x2=self.last_bbox.x2 + dx,
+            y2=self.last_bbox.y2 + dy,
+            confidence=self.last_bbox.confidence,
+        )
+
+    def update_motion(self, bbox: BoundingBox) -> None:
+        if self.last_bbox is not None:
+            old_x, old_y = self.last_bbox.center
+            new_x, new_y = bbox.center
+            measured = (new_x - old_x, new_y - old_y)
+            self.center_velocity = (
+                0.65 * self.center_velocity[0] + 0.35 * measured[0],
+                0.65 * self.center_velocity[1] + 0.35 * measured[1],
+            )

--- a/skellytracker/tests/test_multi_person_tracker.py
+++ b/skellytracker/tests/test_multi_person_tracker.py
@@ -116,6 +116,21 @@ _IMAGE = np.zeros((480, 640, 3), dtype=np.uint8)
 # ---------------------------------------------------------------------------
 
 class TestMultiPersonTracker:
+    def test_limits_candidates_to_two_highest_confidence_people(self):
+        script = {
+            0: [
+                BoundingBox(0, 0, 50, 50, confidence=0.7),
+                BoundingBox(100, 0, 150, 50, confidence=0.95),
+                BoundingBox(200, 0, 250, 50, confidence=0.8),
+            ]
+        }
+        tracker = _make_tracker(script)
+        observation, tracks = tracker.process_image(_IMAGE, 0, {})
+
+        assert len(tracks) == 2
+        assert len(observation.people) == 2
+        assert sorted(track.last_bbox.confidence for track in tracks.values()) == [0.8, 0.95]
+
     def test_two_people_get_stable_distinct_track_ids_across_frames(self):
         # Two people, non-overlapping, drifting slowly — 6 frames.
         script = {

--- a/skellytracker/tests/test_track_association.py
+++ b/skellytracker/tests/test_track_association.py
@@ -133,3 +133,17 @@ class TestAssociate:
         assert result.matches == []
         assert result.unmatched_tracks == [0]
         assert result.unmatched_detections == []
+
+    def test_ambiguous_crossing_holds_tracks_instead_of_swapping(self):
+        config = MultiPersonTrackingConfig(ambiguity_margin=0.1)
+        track_bboxes = [_box(0, 0, 20, 20), _box(0, 0, 20, 20)]
+        track_kpts = [_kpts(10, 10), _kpts(10, 10)]
+        det_bboxes = [_box(1, 0, 21, 20), _box(-1, 0, 19, 20)]
+        det_kpts = [_kpts(10, 10), _kpts(10, 10)]
+
+        result = associate(track_bboxes, track_kpts, det_bboxes, det_kpts, config)
+
+        assert result.matches == []
+        assert result.unmatched_tracks == [0, 1]
+        assert result.unmatched_detections == []
+        assert result.held_detections == [0, 1]


### PR DESCRIPTION
Caps the configured tracker at two high-confidence people, predicts bounding boxes with smoothed velocity before Hungarian association, and holds ambiguous detections instead of swapping identity. Adds deterministic crossing and candidate-limit regression tests. Focused pytest and ruff CI is green.