### PR TITLE
Mediapipe Hand Detection Upgrade using ROI Cropping

### DIFF
--- a/skellytracker/core/detectors/detection_context.py
+++ b/skellytracker/core/detectors/detection_context.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Any
 
 from skellytracker.core.io.processing_timer import ProcessingTimer
 
@@ -25,3 +26,4 @@ class DetectionContext:
     frame_number: int = 0
     timestamp_ms: int | None = None
     timings: ProcessingTimer | None = field(default=None, repr=False)
+    parent_keypoints: Any | None = None

--- a/skellytracker/core/detectors/keypoint_detectors/mediapipe/hands/mediapipe_hand_detector.py
+++ b/skellytracker/core/detectors/keypoint_detectors/mediapipe/hands/mediapipe_hand_detector.py
@@ -30,6 +30,25 @@ _LEFT_NAMES: tuple[str, ...] = tuple(f"left_hand_{n}" for n in _HAND_POINT_NAMES
 _BOTH_HAND_NAMES: tuple[str, ...] = _RIGHT_NAMES + _LEFT_NAMES
 
 
+def crop_hand_roi(image: NDArray[np.uint8], wrist_px: NDArray[np.float64], elbow_px: NDArray[np.float64], margin: float = 1.5) -> tuple[NDArray[np.uint8], tuple[int, int, int, int]]:
+    """
+    Derives a square crop around the hand using wrist and elbow landmarks to estimate scale/orientation.
+    """
+    h, w = image.shape[:2]
+    # Estimate hand length based on forearm proportion (~60-70% of forearm length)
+    forearm_len = np.linalg.norm(wrist_px - elbow_px)
+    box_size = int(forearm_len * margin)
+    
+    # Create bounding box centered around the wrist extending outward
+    x_min = max(0, int(wrist_px[0] - box_size // 2))
+    y_min = max(0, int(wrist_px[1] - box_size // 2))
+    x_max = min(w, int(wrist_px[0] + box_size // 2))
+    y_max = min(h, int(wrist_px[1] + box_size // 2))
+    
+    crop = image[y_min:y_max, x_min:x_max]
+    return crop, (x_min, y_min, x_max - x_min, y_max - y_min)
+
+
 class MediapipeHandDetectorConfig(KeypointDetectorConfig):
     detector_type: Literal["mediapipe_hand"] = "mediapipe_hand"
     session_backend: Literal["mediapipe"] = "mediapipe"
@@ -106,44 +125,70 @@ class MediapipeHandKeypointDetector(KeypointDetector):
         image: NDArray[np.uint8],
         context: DetectionContext | None = None,
     ) -> Keypoints:
-        h, w = image.shape[:2]
-        rgb = _to_rgb(image)
-        mp_image = mp.Image(image_format=mp.ImageFormat.SRGB, data=rgb)
-
-        if self.session.running_mode == "video":
-            ts = (
-                context.timestamp_ms
-                if (context is not None and context.timestamp_ms is not None)
-                else int(time.monotonic() * 1000)
-            )
-            result = self.landmarker.detect_for_video(mp_image, ts)
-        else:
-            result = self.landmarker.detect(mp_image)
-
         right_xyz = np.full((_NUM_HAND_LANDMARKS, 3), np.nan, dtype=np.float64)
         left_xyz = np.full((_NUM_HAND_LANDMARKS, 3), np.nan, dtype=np.float64)
         right_vis = np.zeros(_NUM_HAND_LANDMARKS, dtype=np.float64)
         left_vis = np.zeros(_NUM_HAND_LANDMARKS, dtype=np.float64)
 
-        for i, hand_landmarks in enumerate(result.hand_landmarks):
-            handedness = result.handedness[i]
-            label = handedness[0].category_name  # "Left" or "Right"
+        if context is not None and getattr(context, "parent_keypoints", None) is not None and context.parent_keypoints.n_valid > 0:
+            parent_kpts = context.parent_keypoints
+            # Process each hand independently.
+            for side, wrist_name, elbow_name in (
+                ("left", "left_wrist", "left_elbow"),
+                ("right", "right_wrist", "right_elbow"),
+            ):
+                if not (parent_kpts.has_name(wrist_name) and parent_kpts.has_name(elbow_name)):
+                    continue
+                wrist_xyz = parent_kpts.xyz_by_name(wrist_name)
+                elbow_xyz = parent_kpts.xyz_by_name(elbow_name)
+                if np.isnan(wrist_xyz[0]) or np.isnan(elbow_xyz[0]):
+                    continue
 
-            xyz = np.array(
-                [(lm.x * w, lm.y * h, lm.z * w) for lm in hand_landmarks],
-                dtype=np.float64,
-            )
-            vis = np.array(
-                [lm.presence if lm.presence is not None else 1.0 for lm in hand_landmarks],
-                dtype=np.float64,
-            )
+                crop, origin = crop_hand_roi(image, wrist_xyz[:2], elbow_xyz[:2], margin=2.5)
+                crop_h, crop_w = crop.shape[:2]
+                if crop_h <= 0 or crop_w <= 0:
+                    continue
 
-            if label == "Right":
-                right_xyz = xyz
-                right_vis = vis
-            elif label == "Left":
-                left_xyz = xyz
-                left_vis = vis
+                mp_image = mp.Image(image_format=mp.ImageFormat.SRGB, data=_to_rgb(crop))
+                result = self.landmarker.detect(mp_image)
+                if not result.hand_landmarks:
+                    continue
+                # Take the single best-scored hand found in this ROI and assign it
+                # to the side we seeded, regardless of MediaPipe's handedness label
+                # (which is unreliable on a tight single-hand crop).
+                hand_landmarks = max(
+                    result.hand_landmarks,
+                    key=lambda lm_list: float(
+                        np.mean([lm.presence if lm.presence is not None else 1.0 for lm in lm_list])
+                    ),
+                )
+                ox, oy = int(origin[0]), int(origin[1])
+                xyz = np.array(
+                    [(lm.x * crop_w + ox, lm.y * crop_h + oy, lm.z * crop_w) for lm in hand_landmarks],
+                    dtype=np.float64,
+                )
+                vis = np.array(
+                    [lm.presence if lm.presence is not None else 1.0 for lm in hand_landmarks],
+                    dtype=np.float64,
+                )
+                if side == "right":
+                    right_xyz, right_vis = xyz, vis
+                else:
+                    left_xyz, left_vis = xyz, vis
+        else:
+            # Fallback to full image
+            h, w = image.shape[:2]
+            mp_image = mp.Image(image_format=mp.ImageFormat.SRGB, data=_to_rgb(image))
+            result = self.landmarker.detect(mp_image)
+            for i, hand_landmarks in enumerate(result.hand_landmarks):
+                handedness = result.handedness[i]
+                label = handedness[0].category_name
+                xyz = np.array([(lm.x * w, lm.y * h, lm.z * w) for lm in hand_landmarks], dtype=np.float64)
+                vis = np.array([lm.presence if lm.presence is not None else 1.0 for lm in hand_landmarks], dtype=np.float64)
+                if label == "Right":
+                    right_xyz, right_vis = xyz, vis
+                elif label == "Left":
+                    left_xyz, left_vis = xyz, vis
 
         xyz = np.concatenate([right_xyz, left_xyz], axis=0)
         visibility = np.concatenate([right_vis, left_vis], axis=0)
@@ -182,7 +227,7 @@ class MediapipeHandKeypointDetector(KeypointDetector):
         from mediapipe.tasks.python import BaseOptions
         from mediapipe.tasks.python.vision import HandLandmarker, HandLandmarkerOptions, RunningMode
 
-        mp_running_mode = RunningMode.VIDEO if session.running_mode == "video" else RunningMode.IMAGE
+        mp_running_mode = RunningMode.IMAGE
         hand_path = get_hand_model_path()
         opts = HandLandmarkerOptions(
             base_options=BaseOptions(model_asset_path=str(hand_path)),

--- a/skellytracker/core/detectors/keypoint_detectors/mediapipe/hands/mediapipe_hand_detector.py
+++ b/skellytracker/core/detectors/keypoint_detectors/mediapipe/hands/mediapipe_hand_detector.py
@@ -25,28 +25,150 @@ from skellytracker.core.sessions.mediapipe_session import MediaPipeSession
 _HAND_POINT_NAMES: tuple[str, ...] = load_point_names(Path(__file__).parent / "mediapipe_hand.yaml")
 _NUM_HAND_LANDMARKS = len(_HAND_POINT_NAMES)
 
+# TEMPORARY DEBUG: print crop-box vertices (original-image coords) for the first
+# N frames so boxes can be drawn on frames for inspection. Set to None to disable.
+_CROP_DEBUG_MAX_FRAMES: int | None = 1000
+
+# Selects which crop strategy is used when parent (body) keypoints are available:
+#   - "palm":       palm-aligned, hand-span-sized rotated crop (current behavior)
+#   - "elbow_wrist": axis-aligned square crop centered on the wrist, sized from the
+#                   forearm length (previous behavior)
+# Flip this to switch between the two methods; both print the same debug box
+# vertices (see _CROP_DEBUG_MAX_FRAMES).
+_CROP_METHOD: Literal["elbow_wrist", "palm"] = "palm"
+
 _RIGHT_NAMES: tuple[str, ...] = tuple(f"right_hand_{n}" for n in _HAND_POINT_NAMES)
 _LEFT_NAMES: tuple[str, ...] = tuple(f"left_hand_{n}" for n in _HAND_POINT_NAMES)
 _BOTH_HAND_NAMES: tuple[str, ...] = _RIGHT_NAMES + _LEFT_NAMES
 
 
-def crop_hand_roi(image: NDArray[np.uint8], wrist_px: NDArray[np.float64], elbow_px: NDArray[np.float64], margin: float = 1.5) -> tuple[NDArray[np.uint8], tuple[int, int, int, int]]:
+def crop_hand_roi(
+    image: NDArray[np.uint8],
+    wrist_px: NDArray[np.float64],
+    index_mcp_px: NDArray[np.float64] | None = None,
+    pinky_mcp_px: NDArray[np.float64] | None = None,
+    elbow_px: NDArray[np.float64] | None = None,
+    margin: float = 2.0,
+) -> tuple[NDArray[np.uint8], NDArray[np.float64]]:
+    """Dispatch to the active crop strategy selected by ``_CROP_METHOD``.
+
+    Both strategies return ``(crop, inverse_affine)`` where ``inverse_affine`` is a
+    (2, 3) affine matrix mapping crop-local pixel coordinates back to original-image
+    coordinates, so downstream code (landmark mapping and debug box vertices) is
+    identical regardless of which method is active.
+
+    - ``_CROP_METHOD == "elbow_wrist"`` uses ``elbow_px`` (axis-aligned forearm box).
+    - ``_CROP_METHOD == "palm"`` uses ``index_mcp_px``/``pinky_mcp_px``.
     """
-    Derives a square crop around the hand using wrist and elbow landmarks to estimate scale/orientation.
+    if _CROP_METHOD == "elbow_wrist":
+        if elbow_px is None:
+            raise ValueError("elbow_wrist crop method requires elbow_px")
+        return _crop_hand_roi_elbow_wrist(image, wrist_px, elbow_px, margin=margin)
+    if index_mcp_px is None or pinky_mcp_px is None:
+        raise ValueError("palm crop method requires index_mcp_px and pinky_mcp_px")
+    return _crop_hand_roi_palm(
+        image, wrist_px, index_mcp_px, pinky_mcp_px, margin=margin
+    )
+
+
+def _crop_hand_roi_elbow_wrist(
+    image: NDArray[np.uint8],
+    wrist_px: NDArray[np.float64],
+    elbow_px: NDArray[np.float64],
+    margin: float = 1.5,
+) -> tuple[NDArray[np.uint8], NDArray[np.float64]]:
+    """Derive an axis-aligned square crop around the hand from wrist and elbow.
+
+    Sizes the box from the 2D forearm length (wrist→elbow). This collapses when the
+    arm points toward the camera (forearm foreshortens), which is exactly the failure
+    mode the palm-based strategy was designed to fix.
+
+    Returns:
+        (crop, inverse_affine): the axis-aligned crop and a (2, 3) affine matrix
+        mapping crop-local pixel coordinates back to original-image coordinates.
     """
     h, w = image.shape[:2]
-    # Estimate hand length based on forearm proportion (~60-70% of forearm length)
     forearm_len = np.linalg.norm(wrist_px - elbow_px)
     box_size = int(forearm_len * margin)
-    
-    # Create bounding box centered around the wrist extending outward
+
     x_min = max(0, int(wrist_px[0] - box_size // 2))
     y_min = max(0, int(wrist_px[1] - box_size // 2))
     x_max = min(w, int(wrist_px[0] + box_size // 2))
     y_max = min(h, int(wrist_px[1] + box_size // 2))
-    
+
     crop = image[y_min:y_max, x_min:x_max]
-    return crop, (x_min, y_min, x_max - x_min, y_max - y_min)
+    inv_affine = np.array(
+        [[1.0, 0.0, float(x_min)], [0.0, 1.0, float(y_min)]],
+        dtype=np.float64,
+    )
+    return crop, inv_affine
+
+
+def _crop_hand_roi_palm(
+    image: NDArray[np.uint8],
+    wrist_px: NDArray[np.float64],
+    index_mcp_px: NDArray[np.float64],
+    pinky_mcp_px: NDArray[np.float64],
+    margin: float = 2.0,
+) -> tuple[NDArray[np.uint8], NDArray[np.float64]]:
+    """Derive a palm-aligned, hand-span-sized crop around a hand.
+
+    Mirrors MediaPipe Holistic's hand ROI (``GetHandRectFromPoseLandmarks``):
+    the box is centered on the wrist, oriented to the palm direction (wrist →
+    midpoint of the index & pinky MCPs), and sized from the hand's own span
+    (wrist → index/pinky MCP) rather than from the forearm. The forearm-based
+    size collapses when the arm points toward the camera (2D wrist→elbow length
+    foreshortens), which is why the previous axis-aligned forearm box missed
+    exactly those frames.
+
+    Returns:
+        (crop, inverse_affine): the rotated crop and a (2, 3) affine matrix
+        mapping crop-local pixel coordinates back to original-image coordinates.
+    """
+    import cv2
+    import math
+
+    h, w = image.shape[:2]
+    cx, cy = float(wrist_px[0]), float(wrist_px[1])
+
+    # Palm forward direction (toward the fingers).
+    fx = (float(index_mcp_px[0]) + float(pinky_mcp_px[0])) / 2.0 - cx
+    fy = (float(index_mcp_px[1]) + float(pinky_mcp_px[1])) / 2.0 - cy
+    rotation = math.atan2(fy, fx)
+
+    # Hand span: wrist -> MCP distance (use the larger of index/pinky for safety).
+    span = max(
+        math.hypot(float(index_mcp_px[0]) - cx, float(index_mcp_px[1]) - cy),
+        math.hypot(float(pinky_mcp_px[0]) - cx, float(pinky_mcp_px[1]) - cy),
+    )
+    box_size = max(int(span * 2.0 * margin), 16)
+
+    # Rotate the image so the palm direction becomes horizontal (+x). cv2's
+    # rotation angle is counter-clockwise in image coordinates, so negate the
+    # measured palm angle.
+    M = cv2.getRotationMatrix2D((cx, cy), -math.degrees(rotation), 1.0)
+    rotated = cv2.warpAffine(
+        image, M, (w, h), flags=cv2.INTER_LINEAR, borderMode=cv2.BORDER_REPLICATE
+    )
+
+    # Axis-aligned box around the wrist in the rotated image.
+    x_min = max(0, int(cx - box_size // 2))
+    y_min = max(0, int(cy - box_size // 2))
+    x_max = min(w, x_min + box_size)
+    y_max = min(h, y_min + box_size)
+    crop = rotated[y_min:y_max, x_min:x_max]
+    if crop.size == 0:
+        return crop, np.eye(2, 3, dtype=np.float64)
+
+    # Inverse affine: crop-local -> original image.
+    # forward:  p_rot = M_lin @ p_img + M_t ; p_crop = p_rot - (x_min, y_min)
+    # inverse:  p_img = M_lin^-1 @ p_crop + M_lin^-1 @ ((x_min,y_min) - M_t)
+    invM = cv2.invertAffineTransform(M)  # M_lin^-1, and invM_t = -M_lin^-1 @ M_t
+    off = np.array([float(x_min), float(y_min)])
+    inv_affine = np.zeros((2, 3), dtype=np.float64)
+    inv_affine[:, :2] = invM[:, :2]
+    inv_affine[:, 2] = invM[:, :2] @ off + invM[:, 2]
+    return crop, inv_affine
 
 
 class MediapipeHandDetectorConfig(KeypointDetectorConfig):
@@ -132,22 +254,66 @@ class MediapipeHandKeypointDetector(KeypointDetector):
 
         if context is not None and getattr(context, "parent_keypoints", None) is not None and context.parent_keypoints.n_valid > 0:
             parent_kpts = context.parent_keypoints
-            # Process each hand independently.
-            for side, wrist_name, elbow_name in (
-                ("left", "left_wrist", "left_elbow"),
-                ("right", "right_wrist", "right_elbow"),
-            ):
-                if not (parent_kpts.has_name(wrist_name) and parent_kpts.has_name(elbow_name)):
+            # Process each hand independently using the landmarks the active crop
+            # method needs: elbow for "elbow_wrist", index+pinky MCP for "palm".
+            if _CROP_METHOD == "elbow_wrist":
+                hand_specs = (
+                    ("left", "left_wrist", "left_elbow", None, None),
+                    ("right", "right_wrist", "right_elbow", None, None),
+                )
+            else:
+                hand_specs = (
+                    ("left", "left_wrist", None, "left_index", "left_pinky"),
+                    ("right", "right_wrist", None, "right_index", "right_pinky"),
+                )
+            for side, wrist_name, elbow_name, index_name, pinky_name in hand_specs:
+                required = [wrist_name]
+                if _CROP_METHOD == "elbow_wrist":
+                    required.append(elbow_name)
+                else:
+                    required.extend([index_name, pinky_name])
+                if not all(parent_kpts.has_name(name) for name in required):
                     continue
                 wrist_xyz = parent_kpts.xyz_by_name(wrist_name)
-                elbow_xyz = parent_kpts.xyz_by_name(elbow_name)
-                if np.isnan(wrist_xyz[0]) or np.isnan(elbow_xyz[0]):
+                if np.isnan(wrist_xyz[0]):
                     continue
 
-                crop, origin = crop_hand_roi(image, wrist_xyz[:2], elbow_xyz[:2], margin=2.5)
+                if _CROP_METHOD == "elbow_wrist":
+                    elbow_xyz = parent_kpts.xyz_by_name(elbow_name)
+                    if np.isnan(elbow_xyz[0]):
+                        continue
+                    crop, inv_affine = crop_hand_roi(
+                        image, wrist_xyz[:2], elbow_px=elbow_xyz[:2], margin=2.5
+                    )
+                else:
+                    index_xyz = parent_kpts.xyz_by_name(index_name)
+                    pinky_xyz = parent_kpts.xyz_by_name(pinky_name)
+                    if np.isnan(index_xyz[0]) or np.isnan(pinky_xyz[0]):
+                        continue
+                    crop, inv_affine = crop_hand_roi(
+                        image, wrist_xyz[:2], index_xyz[:2], pinky_xyz[:2], margin=3.0
+                    )
                 crop_h, crop_w = crop.shape[:2]
                 if crop_h <= 0 or crop_w <= 0:
                     continue
+
+                # TEMPORARY DEBUG: print crop-box vertices (original-image coords)
+                # for the first N frames so the box can be drawn for inspection.
+                if _CROP_DEBUG_MAX_FRAMES is not None:
+                    frame_num = context.frame_number if context is not None else -1
+                    if frame_num < _CROP_DEBUG_MAX_FRAMES:
+                        corners_local = np.array(
+                            [[0.0, 0.0], [crop_w, 0.0], [crop_w, crop_h], [0.0, crop_h]],
+                            dtype=np.float64,
+                        )
+                        corners_img = corners_local @ inv_affine[:, :2].T + inv_affine[:, 2]
+                        print(
+                            f"[CROP-DEBUG] frame={frame_num} side={side} "
+                            f"wrist=({wrist_xyz[0]:.1f},{wrist_xyz[1]:.1f}) "
+                            f"crop={crop_w}x{crop_h} "
+                            f"box_vertices_img={[tuple(round(v, 1) for v in c) for c in corners_img]}",
+                            flush=True,
+                        )
 
                 mp_image = mp.Image(image_format=mp.ImageFormat.SRGB, data=_to_rgb(crop))
                 result = self.landmarker.detect(mp_image)
@@ -162,11 +328,15 @@ class MediapipeHandKeypointDetector(KeypointDetector):
                         np.mean([lm.presence if lm.presence is not None else 1.0 for lm in lm_list])
                     ),
                 )
-                ox, oy = int(origin[0]), int(origin[1])
-                xyz = np.array(
-                    [(lm.x * crop_w + ox, lm.y * crop_h + oy, lm.z * crop_w) for lm in hand_landmarks],
+                # Map crop-local pixel coordinates back to full-frame image
+                # coordinates through the inverse affine of the rotated crop.
+                crop_pts = np.array(
+                    [[lm.x * crop_w, lm.y * crop_h] for lm in hand_landmarks],
                     dtype=np.float64,
                 )
+                full_pts = crop_pts @ inv_affine[:, :2].T + inv_affine[:, 2]
+                z = np.array([lm.z * crop_w for lm in hand_landmarks], dtype=np.float64)
+                xyz = np.column_stack([full_pts, z])
                 vis = np.array(
                     [lm.presence if lm.presence is not None else 1.0 for lm in hand_landmarks],
                     dtype=np.float64,

--- a/skellytracker/core/detectors/keypoint_detectors/mediapipe/hands/mediapipe_hand_detector.py
+++ b/skellytracker/core/detectors/keypoint_detectors/mediapipe/hands/mediapipe_hand_detector.py
@@ -25,86 +25,12 @@ from skellytracker.core.sessions.mediapipe_session import MediaPipeSession
 _HAND_POINT_NAMES: tuple[str, ...] = load_point_names(Path(__file__).parent / "mediapipe_hand.yaml")
 _NUM_HAND_LANDMARKS = len(_HAND_POINT_NAMES)
 
-# TEMPORARY DEBUG: print crop-box vertices (original-image coords) for the first
-# N frames so boxes can be drawn on frames for inspection. Set to None to disable.
-_CROP_DEBUG_MAX_FRAMES: int | None = 1000
-
-# Selects which crop strategy is used when parent (body) keypoints are available:
-#   - "palm":       palm-aligned, hand-span-sized rotated crop (current behavior)
-#   - "elbow_wrist": axis-aligned square crop centered on the wrist, sized from the
-#                   forearm length (previous behavior)
-# Flip this to switch between the two methods; both print the same debug box
-# vertices (see _CROP_DEBUG_MAX_FRAMES).
-_CROP_METHOD: Literal["elbow_wrist", "palm"] = "palm"
-
 _RIGHT_NAMES: tuple[str, ...] = tuple(f"right_hand_{n}" for n in _HAND_POINT_NAMES)
 _LEFT_NAMES: tuple[str, ...] = tuple(f"left_hand_{n}" for n in _HAND_POINT_NAMES)
 _BOTH_HAND_NAMES: tuple[str, ...] = _RIGHT_NAMES + _LEFT_NAMES
 
 
 def crop_hand_roi(
-    image: NDArray[np.uint8],
-    wrist_px: NDArray[np.float64],
-    index_mcp_px: NDArray[np.float64] | None = None,
-    pinky_mcp_px: NDArray[np.float64] | None = None,
-    elbow_px: NDArray[np.float64] | None = None,
-    margin: float = 2.0,
-) -> tuple[NDArray[np.uint8], NDArray[np.float64]]:
-    """Dispatch to the active crop strategy selected by ``_CROP_METHOD``.
-
-    Both strategies return ``(crop, inverse_affine)`` where ``inverse_affine`` is a
-    (2, 3) affine matrix mapping crop-local pixel coordinates back to original-image
-    coordinates, so downstream code (landmark mapping and debug box vertices) is
-    identical regardless of which method is active.
-
-    - ``_CROP_METHOD == "elbow_wrist"`` uses ``elbow_px`` (axis-aligned forearm box).
-    - ``_CROP_METHOD == "palm"`` uses ``index_mcp_px``/``pinky_mcp_px``.
-    """
-    if _CROP_METHOD == "elbow_wrist":
-        if elbow_px is None:
-            raise ValueError("elbow_wrist crop method requires elbow_px")
-        return _crop_hand_roi_elbow_wrist(image, wrist_px, elbow_px, margin=margin)
-    if index_mcp_px is None or pinky_mcp_px is None:
-        raise ValueError("palm crop method requires index_mcp_px and pinky_mcp_px")
-    return _crop_hand_roi_palm(
-        image, wrist_px, index_mcp_px, pinky_mcp_px, margin=margin
-    )
-
-
-def _crop_hand_roi_elbow_wrist(
-    image: NDArray[np.uint8],
-    wrist_px: NDArray[np.float64],
-    elbow_px: NDArray[np.float64],
-    margin: float = 1.5,
-) -> tuple[NDArray[np.uint8], NDArray[np.float64]]:
-    """Derive an axis-aligned square crop around the hand from wrist and elbow.
-
-    Sizes the box from the 2D forearm length (wrist→elbow). This collapses when the
-    arm points toward the camera (forearm foreshortens), which is exactly the failure
-    mode the palm-based strategy was designed to fix.
-
-    Returns:
-        (crop, inverse_affine): the axis-aligned crop and a (2, 3) affine matrix
-        mapping crop-local pixel coordinates back to original-image coordinates.
-    """
-    h, w = image.shape[:2]
-    forearm_len = np.linalg.norm(wrist_px - elbow_px)
-    box_size = int(forearm_len * margin)
-
-    x_min = max(0, int(wrist_px[0] - box_size // 2))
-    y_min = max(0, int(wrist_px[1] - box_size // 2))
-    x_max = min(w, int(wrist_px[0] + box_size // 2))
-    y_max = min(h, int(wrist_px[1] + box_size // 2))
-
-    crop = image[y_min:y_max, x_min:x_max]
-    inv_affine = np.array(
-        [[1.0, 0.0, float(x_min)], [0.0, 1.0, float(y_min)]],
-        dtype=np.float64,
-    )
-    return crop, inv_affine
-
-
-def _crop_hand_roi_palm(
     image: NDArray[np.uint8],
     wrist_px: NDArray[np.float64],
     index_mcp_px: NDArray[np.float64],
@@ -262,66 +188,32 @@ class MediapipeHandKeypointDetector(KeypointDetector):
 
         if context is not None and getattr(context, "parent_keypoints", None) is not None and context.parent_keypoints.n_valid > 0:
             parent_kpts = context.parent_keypoints
-            # Process each hand independently using the landmarks the active crop
-            # method needs: elbow for "elbow_wrist", index+pinky MCP for "palm".
-            if _CROP_METHOD == "elbow_wrist":
-                hand_specs = (
-                    ("left", "left_wrist", "left_elbow", None, None),
-                    ("right", "right_wrist", "right_elbow", None, None),
-                )
-            else:
-                hand_specs = (
-                    ("left", "left_wrist", None, "left_index", "left_pinky"),
-                    ("right", "right_wrist", None, "right_index", "right_pinky"),
-                )
-            for side, wrist_name, elbow_name, index_name, pinky_name in hand_specs:
-                required = [wrist_name]
-                if _CROP_METHOD == "elbow_wrist":
-                    required.append(elbow_name)
-                else:
-                    required.extend([index_name, pinky_name])
-                if not all(parent_kpts.has_name(name) for name in required):
+            # Process each hand independently from its wrist + index/pinky MCPs.
+            for side, wrist_name, index_name, pinky_name in (
+                ("left", "left_wrist", "left_index", "left_pinky"),
+                ("right", "right_wrist", "right_index", "right_pinky"),
+            ):
+                if not all(
+                    parent_kpts.has_name(name)
+                    for name in (wrist_name, index_name, pinky_name)
+                ):
                     continue
                 wrist_xyz = parent_kpts.xyz_by_name(wrist_name)
-                if np.isnan(wrist_xyz[0]):
+                index_xyz = parent_kpts.xyz_by_name(index_name)
+                pinky_xyz = parent_kpts.xyz_by_name(pinky_name)
+                if (
+                    np.isnan(wrist_xyz[0])
+                    or np.isnan(index_xyz[0])
+                    or np.isnan(pinky_xyz[0])
+                ):
                     continue
 
-                if _CROP_METHOD == "elbow_wrist":
-                    elbow_xyz = parent_kpts.xyz_by_name(elbow_name)
-                    if np.isnan(elbow_xyz[0]):
-                        continue
-                    crop, inv_affine = crop_hand_roi(
-                        image, wrist_xyz[:2], elbow_px=elbow_xyz[:2], margin=2.5
-                    )
-                else:
-                    index_xyz = parent_kpts.xyz_by_name(index_name)
-                    pinky_xyz = parent_kpts.xyz_by_name(pinky_name)
-                    if np.isnan(index_xyz[0]) or np.isnan(pinky_xyz[0]):
-                        continue
-                    crop, inv_affine = crop_hand_roi(
-                        image, wrist_xyz[:2], index_xyz[:2], pinky_xyz[:2], margin=3.0
-                    )
+                crop, inv_affine = crop_hand_roi(
+                    image, wrist_xyz[:2], index_xyz[:2], pinky_xyz[:2], margin=3.0
+                )
                 crop_h, crop_w = crop.shape[:2]
                 if crop_h <= 0 or crop_w <= 0:
                     continue
-
-                # TEMPORARY DEBUG: print crop-box vertices (original-image coords)
-                # for the first N frames so the box can be drawn for inspection.
-                if _CROP_DEBUG_MAX_FRAMES is not None:
-                    frame_num = context.frame_number if context is not None else -1
-                    if frame_num < _CROP_DEBUG_MAX_FRAMES:
-                        corners_local = np.array(
-                            [[0.0, 0.0], [crop_w, 0.0], [crop_w, crop_h], [0.0, crop_h]],
-                            dtype=np.float64,
-                        )
-                        corners_img = corners_local @ inv_affine[:, :2].T + inv_affine[:, 2]
-                        print(
-                            f"[CROP-DEBUG] frame={frame_num} side={side} "
-                            f"wrist=({wrist_xyz[0]:.1f},{wrist_xyz[1]:.1f}) "
-                            f"crop={crop_w}x{crop_h} "
-                            f"box_vertices_img={[tuple(round(v, 1) for v in c) for c in corners_img]}",
-                            flush=True,
-                        )
 
                 mp_image = mp.Image(image_format=mp.ImageFormat.SRGB, data=_to_rgb(crop))
                 result = self.landmarker.detect(mp_image)

--- a/skellytracker/core/detectors/keypoint_detectors/mediapipe/hands/mediapipe_hand_detector.py
+++ b/skellytracker/core/detectors/keypoint_detectors/mediapipe/hands/mediapipe_hand_detector.py
@@ -109,17 +109,17 @@ def _crop_hand_roi_palm(
     wrist_px: NDArray[np.float64],
     index_mcp_px: NDArray[np.float64],
     pinky_mcp_px: NDArray[np.float64],
-    margin: float = 2.0,
+    margin: float = 1.5,
 ) -> tuple[NDArray[np.uint8], NDArray[np.float64]]:
     """Derive a palm-aligned, hand-span-sized crop around a hand.
 
     Mirrors MediaPipe Holistic's hand ROI (``GetHandRectFromPoseLandmarks``):
-    the box is centered on the wrist, oriented to the palm direction (wrist →
-    midpoint of the index & pinky MCPs), and sized from the hand's own span
-    (wrist → index/pinky MCP) rather than from the forearm. The forearm-based
-    size collapses when the arm points toward the camera (2D wrist→elbow length
-    foreshortens), which is why the previous axis-aligned forearm box missed
-    exactly those frames.
+    the box is centered on the palm (midpoint of the index & pinky MCPs),
+    oriented to the palm direction (wrist → that midpoint), and sized from the
+    hand's own span (wrist → index/pinky MCP) rather than from the forearm.
+    Centering on the palm (rather than the wrist) shifts the box forward over
+    the fingers, so a small margin still covers the fingertips while the box
+    stays small enough not to swallow a nearby other hand.
 
     Returns:
         (crop, inverse_affine): the rotated crop and a (2, 3) affine matrix
@@ -129,17 +129,25 @@ def _crop_hand_roi_palm(
     import math
 
     h, w = image.shape[:2]
-    cx, cy = float(wrist_px[0]), float(wrist_px[1])
+    wx, wy = float(wrist_px[0]), float(wrist_px[1])
 
-    # Palm forward direction (toward the fingers).
-    fx = (float(index_mcp_px[0]) + float(pinky_mcp_px[0])) / 2.0 - cx
-    fy = (float(index_mcp_px[1]) + float(pinky_mcp_px[1])) / 2.0 - cy
+    # Palm center: midpoint of the index & pinky MCPs (the geometric center of
+    # the palm). Centering here (rather than on the wrist) shifts the box
+    # forward over the fingers, so a much smaller margin still covers the
+    # fingertips while the box stays small enough not to swallow a nearby hand.
+    cx, cy = (
+        (float(index_mcp_px[0]) + float(pinky_mcp_px[0])) / 2.0,
+        (float(index_mcp_px[1]) + float(pinky_mcp_px[1])) / 2.0,
+    )
+
+    # Palm forward direction (toward the fingers), wrist -> palm center.
+    fx, fy = cx - wx, cy - wy
     rotation = math.atan2(fy, fx)
 
     # Hand span: wrist -> MCP distance (use the larger of index/pinky for safety).
     span = max(
-        math.hypot(float(index_mcp_px[0]) - cx, float(index_mcp_px[1]) - cy),
-        math.hypot(float(pinky_mcp_px[0]) - cx, float(pinky_mcp_px[1]) - cy),
+        math.hypot(float(index_mcp_px[0]) - wx, float(index_mcp_px[1]) - wy),
+        math.hypot(float(pinky_mcp_px[0]) - wx, float(pinky_mcp_px[1]) - wy),
     )
     box_size = max(int(span * 2.0 * margin), 16)
 
@@ -151,7 +159,7 @@ def _crop_hand_roi_palm(
         image, M, (w, h), flags=cv2.INTER_LINEAR, borderMode=cv2.BORDER_REPLICATE
     )
 
-    # Axis-aligned box around the wrist in the rotated image.
+    # Axis-aligned box around the palm center in the rotated image.
     x_min = max(0, int(cx - box_size // 2))
     y_min = max(0, int(cy - box_size // 2))
     x_max = min(w, x_min + box_size)

--- a/skellytracker/core/tracker/detection_stage.py
+++ b/skellytracker/core/tracker/detection_stage.py
@@ -107,6 +107,9 @@ class DetectionStage:
         Returns:
             (StageObservation, updated StageState)
         """
+        if context is not None and parent_keypoints is not None:
+            import dataclasses
+            context = dataclasses.replace(context, parent_keypoints=parent_keypoints)
         frame_number = context.frame_number if context is not None else 0
         dt = _dt_from_context(context)
 
@@ -376,6 +379,7 @@ class DetectionStage:
         images: dict[str, NDArray[np.uint8]],
         states: dict[str, StageState],
         context: DetectionContext | None = None,
+        parent_keypoints_per_cam: dict[str, Keypoints | None] | None = None,
     ) -> tuple[dict[str, StageObservation], dict[str, StageState]]:
         """Run this stage on N cameras simultaneously.
 
@@ -596,7 +600,9 @@ class DetectionStage:
                     if cam_id not in cam_detectors:
                         cam_detectors[cam_id] = type(detector).create(detector.config, detector.session)
                     cam_detector = cam_detectors[cam_id]
-                    kpts = cam_detector.detect(crops[cam_id], context)
+                    import dataclasses
+                    cam_context = dataclasses.replace(context, parent_keypoints=parent_keypoints_per_cam[cam_id]) if context and parent_keypoints_per_cam and parent_keypoints_per_cam.get(cam_id) else context
+                    kpts = cam_detector.detect(crops[cam_id], cam_context)
                     cb = crop_bboxes[cam_id]
                     if cb is not None:
                         kpts = kpts.translated(cb.x1, cb.y1)
@@ -658,7 +664,7 @@ class DetectionStage:
                 cam_id: states.get(cam_id, StageState()).child_states.get(child.name, StageState())
                 for cam_id in cam_ids
             }
-            child_obs_batch, child_states_batch = child.run_batch(crops, child_stage_states, context)
+            child_obs_batch, child_states_batch = child.run_batch(crops, child_stage_states, context, parent_keypoints_per_cam=merged_per_cam)
             for cam_id in cam_ids:
                 child_obs_per_cam[cam_id][child.name] = child_obs_batch[cam_id]
                 child_states_per_cam[cam_id][child.name] = child_states_batch[cam_id]


### PR DESCRIPTION
Here is a proposed upgrade for the hand detection of the mediapipe detector.
In the new MediaPipe Tasks API setup, detectors run independently without a hierarchical cascade. As a result, HandLandmarker runs on the entire full-resolution frame. Because hands occupy a very small percentage of a full-body mocap frame, the detection rate drops significantly compared to v1.8.2 (which used MediaPipe Holistic). This leads to missing hand tracking and corrupted/invalid bone lengths.

This PR does the following:
- Adds parent_keypoints to DetectionContext and DetectionStage in skellytracker, allowing mediapipe_hand_detector to consume body keypoints to derive a Region of Interest (ROI).
- Adds a Hand ROI Crop logic to apply the detector only to a cropped image based on the index, pinky and wrist markers.

This is a comparison of the methods:
<img width="1074" height="539" alt="image" src="https://github.com/user-attachments/assets/c05a4b32-703b-4089-84f1-d1b016b5ba7c" />
